### PR TITLE
Lock GitHub version to work around crash

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = "~> 0.12.0"
+
+  required_providers {
+    github = "2.4.0"
+  }
 }


### PR DESCRIPTION
Latest Github provider (possibly) crashes due to an update to the latest GO library. Until a fix is in place in the provider, lock the version to the previous (working) version.

**Sources:**
* https://github.com/terraform-providers/terraform-provider-github/pull/342
* https://github.com/google/go-github/pull/1288
