### PR TITLE
Remove GitHub version lock

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -1,7 +1,3 @@
 terraform {
   required_version = "~> 0.12.0"
-
-  required_providers {
-    github = "2.4.0"
-  }
 }


### PR DESCRIPTION
Crash has been fixes in latest release. Remove version lock.

Links:

* https://github.com/terraform-providers/terraform-provider-github/blob/master/CHANGELOG.md#250-march-30-2020
* https://github.com/schubergphilis/terraform-github-mcaf-repository/pull/5