### PR TITLE
Fix deprecation warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "github_repository" "default" {
   has_projects           = var.has_projects
   has_wiki               = var.has_wiki
   is_template            = var.is_template
-  private                = var.private
+  visibility             = var.visibility
 }
 
 resource "github_team_repository" "admins" {

--- a/variables.tf
+++ b/variables.tf
@@ -109,16 +109,16 @@ variable "is_template" {
   description = "To mark this repository as a template repository."
 }
 
-variable "private" {
-  type        = bool
-  default     = true
-  description = "Make the Github repository private"
-}
-
 variable "readers" {
   type        = list(string)
   default     = []
   description = "A list of Github teams that should have read access"
+}
+
+variable "visibility" {
+  type        = bool
+  default     = "private"
+  description = "The visiblity (internal, private or public) of the Github repository"
 }
 
 variable "writers" {

--- a/version.tf
+++ b/version.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    github = "2.9.0"
+    github >= "2.9.0"
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = "~> 0.12.0"
+
+  required_providers {
+    github = "2.9.0"
+  }
 }


### PR DESCRIPTION
In the latest version of the Github provider they introduced `visibility` as a replacement for `private`. ([source](https://github.com/terraform-providers/terraform-provider-github/blob/master/CHANGELOG.md#290-june-29-2020))

In this change the `private` option got deprecated.

This PR replaces the `private` variable with `visibility`. Default value is still `private`