### PR TITLE
Data source depends on gitub_repository when created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 data "github_repository" "default" {
-  name = try(github_repository.default.0.name, var.name)
+  name = var.create_repository ? github_repository.default.0.name : var.name
 }
 
 resource "github_repository" "default" {


### PR DESCRIPTION
This way the datasource will wait on the github_repository resource (if any exists) before checking with Github. This way you won't get a 404 when you check a repo that hasn't been created, yet.