### PR TITLE
Drop create_repository variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,6 @@ data "github_repository" "default" {
 }
 
 resource "github_repository" "default" {
-  count                  = var.create_repository ? 1 : 0
   name                   = var.name
   description            = var.description
   allow_rebase_merge     = var.allow_rebase_merge

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,6 @@ locals {
   ])
 }
 
-data "github_repository" "default" {
-  name = try(github_repository.default.0.name, var.name)
-
-  depends_on = [github_repository.default]
-}
-
 resource "github_repository" "default" {
   name                   = var.name
   description            = var.description
@@ -81,7 +75,7 @@ resource "github_branch_protection" "default" {
   enforce_admins    = local.protection[count.index].enforce_admins
   pattern           = local.protection[count.index].branch
   push_restrictions = local.protection[count.index].push_restrictions
-  repository_id     = data.github_repository.default.node_id
+  repository_id     = github_repository.default.node_id
 
   dynamic required_pull_request_reviews {
     for_each = local.protection[count.index].required_reviews != null ? { create : true } : {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "full_name" {
-  value       = try(github_repository.default[0].full_name, null)
+  value       = try(github_repository.default.full_name, null)
   description = "The full 'organization/repository' name of the repository"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,5 @@
-variable "create_repository" {
-  type        = bool
-  default     = true
-  description = "Whether or not to create a new repository"
-}
-
 variable "name" {
   type        = string
-  default     = null
   description = "The name of the repository"
 }
 


### PR DESCRIPTION
This variable was added while still using Terraform 0.12 and allowed us to include this module in another module and making creation of a new repo optional as using `count` on a module was not supported.

Since Terraform 0.13 was released we can use `count` on a module and it's better to skip the module completely if the `create_repository` variable is set to `false` in the calling module instead of just the `github_repository` resource, example:

```hcl
module "github_repository" {
  count = var.create_repository ? 1 : 0
  ...
```

Another consideration is a repository should either be managed by this module or not. Currently there is a catch 22 situation where a new repo cannot be created because the `data` resource fails because the repo doesn't exist yet.