### PR TITLE
Add support for Github Actions secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ MCAF Terraform module to create and manage a GitHub repository.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | name | The name of the repository | `string` | n/a | yes |
+| actions\_secrets | An optional map with Github action secrets | `map(string)` | `{}` | no |
 | admins | A list of Github teams that should have admins access | `list(string)` | `[]` | no |
 | allow\_rebase\_merge | To enable rebase merges on the repository | `bool` | `false` | no |
 | allow\_squash\_merge | To enable squash merges on the repository | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -94,3 +94,10 @@ resource "github_branch_protection" "default" {
     github_repository.default
   ]
 }
+
+resource "github_actions_secret" "secrets" {
+  for_each        = var.actions_secrets
+  repository      = github_repository.default.name
+  secret_name     = each.key
+  plaintext_value = each.value
+}

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "github_branch_protection" "default" {
   push_restrictions = local.protection[count.index].push_restrictions
   repository_id     = github_repository.default.node_id
 
-  dynamic required_pull_request_reviews {
+  dynamic "required_pull_request_reviews" {
     for_each = local.protection[count.index].required_reviews != null ? { create : true } : {}
 
     content {

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ resource "github_branch_protection" "default" {
     }
   }
 
-  dynamic required_status_checks {
+  dynamic "required_status_checks" {
     for_each = local.protection[count.index].required_checks != null ? { create : true } : {}
 
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   description = "The name of the repository"
 }
 
+variable "actions_secrets" {
+  type        = map(string)
+  default     = {}
+  description = "An optional map with Github action secrets"
+}
+
 variable "admins" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
Add a `actions_secrets` variables to add support for [Github actions secrets](https://www.terraform.io/docs/providers/github/r/actions_secret.html)