### PR TITLE
Change source branch to master instead of main

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ MCAF Terraform module to create and manage a GitHub repository.
 | archived | Specifies if the repository should be archived | `bool` | `false` | no |
 | auto\_init | Disable to not produce an initial commit in the repository | `bool` | `true` | no |
 | branch\_protection | The Github branches to protect from forced pushes and deletion | <pre>list(object({<br>    branches          = list(string)<br>    enforce_admins    = bool<br>    push_restrictions = list(string)<br><br>    required_reviews = object({<br>      dismiss_stale_reviews           = bool<br>      dismissal_restrictions          = list(string)<br>      required_approving_review_count = number<br>      require_code_owner_reviews      = bool<br>    })<br><br>    required_checks = object({<br>      strict   = bool<br>      contexts = list(string)<br>    })<br>  }))</pre> | `[]` | no |
+| branch\_sources | Branches with a source different than the default branch | `map(string)` | `null` | no |
 | default\_branch | The default branch for the Github repository | `string` | `"master"` | no |
 | delete\_branch\_on\_merge | Automatically delete head branch after a pull request is merged | `bool` | `false` | no |
 | description | A description for the Github repository | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ MCAF Terraform module to create and manage a GitHub repository.
 | archived | Specifies if the repository should be archived | `bool` | `false` | no |
 | auto\_init | Disable to not produce an initial commit in the repository | `bool` | `true` | no |
 | branch\_protection | The Github branches to protect from forced pushes and deletion | <pre>list(object({<br>    branches          = list(string)<br>    enforce_admins    = bool<br>    push_restrictions = list(string)<br><br>    required_reviews = object({<br>      dismiss_stale_reviews           = bool<br>      dismissal_restrictions          = list(string)<br>      required_approving_review_count = number<br>      require_code_owner_reviews      = bool<br>    })<br><br>    required_checks = object({<br>      strict   = bool<br>      contexts = list(string)<br>    })<br>  }))</pre> | `[]` | no |
+| default\_branch | The default branch for the Github repository | `string` | `"master"` | no |
 | delete\_branch\_on\_merge | Automatically delete head branch after a pull request is merged | `bool` | `false` | no |
 | description | A description for the Github repository | `string` | `null` | no |
 | gitignore\_template | The name of the template without the extension | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -36,9 +36,10 @@ resource "github_repository" "default" {
 }
 
 resource "github_branch" "default" {
-  for_each   = local.branches
-  branch     = each.value
-  repository = github_repository.default.name
+  for_each      = local.branches
+  branch        = each.value
+  repository    = github_repository.default.name
+  source_branch = "master"
 }
 
 resource "github_team_repository" "admins" {

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "github_branch" "default" {
   for_each      = local.branches
   branch        = each.value
   repository    = github_repository.default.name
-  source_branch = var.default_branch
+  source_branch = try(var.branch_sources[each.value], var.default_branch)
 }
 
 resource "github_team_repository" "admins" {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
     for config in var.branch_protection : [
       config.branches
     ]
-  ]), ["master"])
+  ]), [var.default_branch])
 
   protection = flatten([
     for config in var.branch_protection : [
@@ -39,7 +39,7 @@ resource "github_branch" "default" {
   for_each      = local.branches
   branch        = each.value
   repository    = github_repository.default.name
-  source_branch = "master"
+  source_branch = var.default_branch
 }
 
 resource "github_team_repository" "admins" {

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,12 @@ variable "description" {
   description = "A description for the Github repository"
 }
 
+variable "default_branch" {
+  type        = string
+  default     = "master"
+  description = "The default branch for the Github repository"
+}
+
 variable "gitignore_template" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,18 @@ variable "branch_protection" {
   description = "The Github branches to protect from forced pushes and deletion"
 }
 
+variable "branch_sources" {
+  type        = map(string)
+  default     = null
+  description = "Branches with a source different than the default branch"
+}
+
+variable "default_branch" {
+  type        = string
+  default     = "master"
+  description = "The default branch for the Github repository"
+}
+
 variable "delete_branch_on_merge" {
   type        = bool
   default     = false
@@ -71,12 +83,6 @@ variable "description" {
   type        = string
   default     = null
   description = "A description for the Github repository"
-}
-
-variable "default_branch" {
-  type        = string
-  default     = "master"
-  description = "The default branch for the Github repository"
 }
 
 variable "gitignore_template" {


### PR DESCRIPTION
From version `4.5.2`, the Github provider uses `main` as the default source branch for new branches instead of `master`: https://registry.terraform.io/providers/integrations/github/4.5.2/docs/resources/branch

This causes the following error when creating new branches in existing repos:
```hcl
Error: Error querying GitHub branch reference ... (refs/heads/main): GET https://api.github.com/repos/.../git/ref/heads/main: 404 Not Found []

  on .terraform/modules/github_repos/main.tf line 38, in resource "github_branch" "default":
  38: resource "github_branch" "default" {
```

Since we already use `master` as the [default branch for our repos](https://github.com/schubergphilis/terraform-github-mcaf-repository/blob/master/main.tf#L6), this change sets it as the source for all new branches.