### PR TITLE
Update provider source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Crash log files
 crash.log
 
+# Terraform lock file
+.terraform.lock.hcl
+
 # Ignore any .tfvars files that are generated automatically for each Terraform run. Most
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MCAF Terraform module to create and manage a GitHub repository.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12 |
+| terraform | >= 0.13 |
 | github | >= 3.1.0 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 
   required_providers {
     github = {
-      source  = "hashicorp/github"
+      source  = "integrations/github"
       version = ">= 3.1.0"
     }
   }


### PR DESCRIPTION
This PR fixes the following warning:

```│ Warning: Additional provider information from registry
│ 
│ The remote registry returned warnings for registry.terraform.io/hashicorp/github:
│ - For users on Terraform 0.13 or greater, this provider has moved to integrations/github. Please update your source in required_providers.
```