### PR TITLE
Use repository name as the repository_id for branch protection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "github_branch_protection" "default" {
   enforce_admins    = local.protection[count.index].enforce_admins
   pattern           = local.protection[count.index].branch
   push_restrictions = local.protection[count.index].push_restrictions
-  repository_id     = github_repository.default.node_id
+  repository_id     = github_repository.default.name
 
   dynamic "required_pull_request_reviews" {
     for_each = local.protection[count.index].required_reviews != null ? { create : true } : {}


### PR DESCRIPTION
This resolves issue caused by moving to use the v4 API for this resouce, as part of provider version: 3.1.0

Issue: https://github.com/integrations/terraform-provider-github/issues/908
Provider bump: https://github.com/integrations/terraform-provider-github/pull/337