### PR TITLE
Ignore pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ MCAF Terraform module to create and manage a GitHub repository.
 | has\_issues | To enable GitHub Issues features on the repository | `bool` | `false` | no |
 | has\_projects | To enable GitHub Projects features on the repository | `bool` | `false` | no |
 | has\_wiki | To enable GitHub Wiki features on the repository | `bool` | `false` | no |
-| is\_template | To mark this repository as a template repository. | `bool` | `false` | no |
+| is\_template | To mark this repository as a template repository | `bool` | `false` | no |
 | readers | A list of GitHub teams that should have read access | `list(string)` | `[]` | no |
 | repository\_files | A list of GitHub repository files that should be created | <pre>map(object({<br>    path    = string<br>    content = string<br>  }))</pre> | `{}` | no |
 | template\_repository | The settings of the template repostitory to use on creation | <pre>object({<br>    owner      = string<br>    repository = string<br>  })</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,10 @@ resource "github_repository" "default" {
       repository = var.template_repository.repository
     }
   }
+
+  lifecycle {
+    ignore_changes = [pages]
+  }
 }
 
 resource "github_branch" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,7 @@ variable "has_wiki" {
 variable "is_template" {
   type        = bool
   default     = false
-  description = "To mark this repository as a template repository."
+  description = "To mark this repository as a template repository"
 }
 
 variable "readers" {


### PR DESCRIPTION
Ignore changes to pages property. This way it won't remove otherwise configured pages when using the new GH provider

Related issue that proposes moving it to it's own resource: https://github.com/integrations/terraform-provider-github/issues/782