### PR TITLE
Expect the default branch to be "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ MCAF Terraform module to create and manage a GitHub repository.
 | archived | Specifies if the repository should be archived | `bool` | `false` | no |
 | auto\_init | Disable to not produce an initial commit in the repository | `bool` | `true` | no |
 | branch\_protection | The GitHub branches to protect from forced pushes and deletion | <pre>list(object({<br>    branches          = list(string)<br>    enforce_admins    = bool<br>    push_restrictions = list(string)<br><br>    required_reviews = object({<br>      dismiss_stale_reviews           = bool<br>      dismissal_restrictions          = list(string)<br>      required_approving_review_count = number<br>      require_code_owner_reviews      = bool<br>    })<br><br>    required_checks = object({<br>      strict   = bool<br>      contexts = list(string)<br>    })<br>  }))</pre> | `[]` | no |
-| default\_branch | Name of the default branch for the GitHub repository | `string` | `"master"` | no |
-| delete\_branch\_on\_merge | Automatically delete head branch after a pull request is merged | `bool` | `false` | no |
+| default\_branch | Name of the default branch for the GitHub repository | `string` | `"main"` | no |
+| delete\_branch\_on\_merge | Automatically delete head branch after a pull request is merged | `bool` | `true` | no |
 | description | A description for the GitHub repository | `string` | `null` | no |
 | gitignore\_template | The name of the template without the extension | `string` | `null` | no |
 | has\_downloads | To enable downloads features on the repository | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,11 @@
 locals {
-  branches = setsubtract(flatten([
+  default_branch = "main"
+
+  branches = setsubtract(flatten([[
     for config in var.branch_protection : [
       config.branches
     ]
-  ]), [var.default_branch])
+  ], [var.default_branch]]), [local.default_branch])
 
   protection = flatten([
     for config in var.branch_protection : [
@@ -55,6 +57,13 @@ resource "github_branch" "default" {
   for_each   = local.branches
   branch     = each.value
   repository = github_repository.default.name
+}
+
+resource "github_branch_default" "default" {
+  count      = var.default_branch != local.default_branch ? 1 : 0
+  branch     = var.default_branch
+  repository = github_repository.default.name
+  depends_on = [github_branch.default]
 }
 
 resource "github_team_repository" "admins" {

--- a/variables.tf
+++ b/variables.tf
@@ -63,13 +63,13 @@ variable "branch_protection" {
 
 variable "default_branch" {
   type        = string
-  default     = "master"
+  default     = "main"
   description = "Name of the default branch for the GitHub repository"
 }
 
 variable "delete_branch_on_merge" {
   type        = bool
-  default     = false
+  default     = true
   description = "Automatically delete head branch after a pull request is merged"
 }
 
@@ -150,4 +150,3 @@ variable "writers" {
   default     = []
   description = "A list of GitHub teams that should have write access"
 }
-


### PR DESCRIPTION
This still allows you to create additional branches and set another branch as the default branch, but it turns out that nowadays a repo is always initially created with a main branch.

So if you want to use another default branch, you will first need to create it and then update the config to point to the new branch.

This PR enables that again as it turned out this doesn't currently work anymore.