### PR TITLE
Add support for Github environments

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Update module usage docs and push any changes back to PR branch
         uses: Dirrk/terraform-docs@v1.0.8
         with:
-          tf_docs_args: '--sort-inputs-by-required'
-          tf_docs_git_commit_message: 'terraform-docs: Update module usage'
-          tf_docs_git_push: 'true'
+          tf_docs_args: "--sort-inputs-by-required"
+          tf_docs_git_commit_message: "terraform-docs: Update module usage"
+          tf_docs_git_push: "true"
           tf_docs_output_file: README.md
           tf_docs_output_method: inject
           tf_docs_find_dir: .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,4 +64,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.1
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.1.0
+        with:
+          github_token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ MCAF Terraform module to create and manage a GitHub repository.
 | default\_branch | Name of the default branch for the GitHub repository | `string` | `"main"` | no |
 | delete\_branch\_on\_merge | Automatically delete head branch after a pull request is merged | `bool` | `true` | no |
 | description | A description for the GitHub repository | `string` | `null` | no |
-| environments | An optional map with GitHub environments that should be configured for reviewers and deployment branch policies | <pre>map(object({<br>    deployment_branch_policy = object({<br>      custom_branch_policies = bool<br>      protected_branches     = bool<br>    })<br><br>    reviewers = object({<br>      teams = list(string)<br>      users = list(string)<br>    })<br><br>    secrets = map(string)<br><br>    wait_timer = number<br>  }))</pre> | `{}` | no |
+| environments | An optional map with GitHub environments to configure | <pre>map(object({<br>    secrets    = map(string)<br>    wait_timer = number<br><br>    deployment_branch_policy = object({<br>      custom_branch_policies = bool<br>      protected_branches     = bool<br>    })<br><br>    reviewers = object({<br>      teams = list(string)<br>      users = list(string)<br>    })<br>  }))</pre> | `{}` | no |
 | gitignore\_template | The name of the template without the extension | `string` | `null` | no |
 | has\_downloads | To enable downloads features on the repository | `bool` | `false` | no |
 | has\_issues | To enable GitHub Issues features on the repository | `bool` | `false` | no |

--- a/environments.tf
+++ b/environments.tf
@@ -1,0 +1,57 @@
+locals {
+  environment_secrets = flatten([
+    for env, config in var.environments : [
+      for secret_name, secret_value in config.secrets : {
+        environment = env
+        name        = secret_name
+        value       = secret_value
+      }
+    ]
+  ])
+
+  github_team_slugs = toset(flatten([
+    for config in values(var.environments) : config.reviewers.teams
+  ]))
+
+  github_usernames = toset(flatten([
+    for config in values(var.environments) : config.reviewers.users
+  ]))
+}
+
+data "github_user" "default" {
+  for_each = local.github_usernames
+  username = each.key
+}
+
+data "github_team" "default" {
+  for_each = local.github_team_slugs
+  slug     = each.key
+}
+
+resource "github_actions_environment_secret" "secrets" {
+  for_each = {
+    for secret in local.environment_secrets : "${secret.environment}:${secret.name}" => secret
+  }
+
+  environment     = github_repository_environment.default[each.value.environment].environment
+  plaintext_value = each.value.value
+  repository      = github_repository.default.name
+  secret_name     = each.value.name
+}
+
+resource "github_repository_environment" "default" {
+  for_each    = var.environments
+  environment = each.key
+  repository  = github_repository.default.name
+  wait_timer  = each.value.wait_timer
+
+  deployment_branch_policy {
+    custom_branch_policies = each.value.deployment_branch_policy.custom_branch_policies
+    protected_branches     = each.value.deployment_branch_policy.protected_branches
+  }
+
+  reviewers {
+    teams = [for team_slug in each.value.reviewers.teams : data.github_team.default[team_slug].id]
+    users = [for username in each.value.reviewers.users : data.github_user.default[username].id]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,16 @@ locals {
     ]
   ], [var.default_branch]]), [local.default_branch])
 
+  environment_secrets = flatten([
+    for env, spec in var.environments : [
+      for secret_name, secret_value in spec.secrets : {
+        environment = env
+        name        = secret_name
+        value       = secret_value
+      }
+    ]
+  ])
+
   github_team_slugs = toset(flatten([
     for spec in values(var.environments) : spec.reviewers.teams
   ]))
@@ -173,6 +183,15 @@ resource "github_repository_environment" "default" {
     teams = [for team_slug in each.value.reviewers.teams : data.github_team.default[team_slug].id]
     users = [for username in each.value.reviewers.users : data.github_user.default[username].id]
   }
+}
+
+resource "github_actions_environment_secret" "secrets" {
+  for_each = { for secret in local.environment_secrets : "${secret.environment}:${secret.name}" => secret }
+
+  repository   = github_repository.default.name
+  environment  = each.value.environment
+  secret_name  = each.value.name
+  secret_value = each.value.value
 }
 
 resource "github_actions_secret" "secrets" {

--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,10 @@ locals {
   ])
 
   github_usernames = toset(flatten([
-    for env, spec in var.environments : spec.reviewers.users
+    for spec in values(var.environments) : spec.reviewers.users
   ]))
   github_team_slugs = toset(flatten([
-    for env, spec in var.environments : spec.reviewers.teams
+    for spec in values(var.environments) : spec.reviewers.teams
   ]))
 
   template_repository = var.template_repository != null ? { create = true } : {}

--- a/main.tf
+++ b/main.tf
@@ -188,10 +188,10 @@ resource "github_repository_environment" "default" {
 resource "github_actions_environment_secret" "secrets" {
   for_each = { for secret in local.environment_secrets : "${secret.environment}:${secret.name}" => secret }
 
-  repository   = github_repository.default.name
-  environment  = each.value.environment
-  secret_name  = each.value.name
-  secret_value = each.value.value
+  repository      = github_repository.default.name
+  environment     = each.value.environment
+  secret_name     = each.value.name
+  plaintext_value = each.value.value
 }
 
 resource "github_actions_secret" "secrets" {

--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,23 @@ resource "github_branch_protection" "default" {
   ]
 }
 
+resource "github_repository_environment" "default" {
+  for_each = var.environments
+
+  environment = each.key
+  repository  = github_repository.default.name
+
+  reviewers {
+    teams = each.value.reviewers.teams
+    users = each.value.reviewers.users
+  }
+
+  deployment_branch_policy {
+    protected_branches     = each.value.deployment_branch_policy.protected_branches
+    custom_branch_policies = each.value.deployment_branch_policy.custom_branch_policies
+  }
+}
+
 resource "github_actions_secret" "secrets" {
   for_each        = var.actions_secrets
   repository      = github_repository.default.name

--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,7 @@ resource "github_actions_environment_secret" "secrets" {
   for_each = { for secret in local.environment_secrets : "${secret.environment}:${secret.name}" => secret }
 
   repository      = github_repository.default.name
-  environment     = each.value.environment
+  environment     = github_repository_environment.default[each.value.environment].environment
   secret_name     = each.value.name
   plaintext_value = each.value.value
 }

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,14 @@ locals {
     ]
   ], [var.default_branch]]), [local.default_branch])
 
+  github_team_slugs = toset(flatten([
+    for spec in values(var.environments) : spec.reviewers.teams
+  ]))
+
+  github_usernames = toset(flatten([
+    for spec in values(var.environments) : spec.reviewers.users
+  ]))
+
   protection = flatten([
     for config in var.branch_protection : [
       for branch in config.branches : {
@@ -19,13 +27,6 @@ locals {
       }
     ]
   ])
-
-  github_usernames = toset(flatten([
-    for spec in values(var.environments) : spec.reviewers.users
-  ]))
-  github_team_slugs = toset(flatten([
-    for spec in values(var.environments) : spec.reviewers.teams
-  ]))
 
   template_repository = var.template_repository != null ? { create = true } : {}
 }
@@ -164,8 +165,8 @@ resource "github_repository_environment" "default" {
   wait_timer  = each.value.wait_timer
 
   deployment_branch_policy {
-    protected_branches     = each.value.deployment_branch_policy.protected_branches
     custom_branch_policies = each.value.deployment_branch_policy.custom_branch_policies
+    protected_branches     = each.value.deployment_branch_policy.protected_branches
   }
 
   reviewers {

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,13 @@ locals {
     ]
   ])
 
+  github_usernames = toset(flatten([
+    for env, spec in var.environments : spec.reviewers.users
+  ]))
+  github_team_slugs = toset(flatten([
+    for env, spec in var.environments : spec.reviewers.teams
+  ]))
+
   template_repository = var.template_repository != null ? { create = true } : {}
 }
 
@@ -139,20 +146,31 @@ resource "github_branch_protection" "default" {
   ]
 }
 
+data "github_user" "default" {
+  for_each = local.github_usernames
+  username = each.key
+}
+
+data "github_team" "default" {
+  for_each = local.github_team_slugs
+  slug     = each.key
+}
+
 resource "github_repository_environment" "default" {
   for_each = var.environments
 
   environment = each.key
   repository  = github_repository.default.name
-
-  reviewers {
-    teams = each.value.reviewers.teams
-    users = each.value.reviewers.users
-  }
+  wait_timer  = each.value.wait_timer
 
   deployment_branch_policy {
     protected_branches     = each.value.deployment_branch_policy.protected_branches
     custom_branch_policies = each.value.deployment_branch_policy.custom_branch_policies
+  }
+
+  reviewers {
+    teams = [for team_slug in each.value.reviewers.teams : data.github_team.default[team_slug].id]
+    users = [for username in each.value.reviewers.users : data.github_user.default[username].id]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,13 +83,13 @@ variable "description" {
 variable "environments" {
   type = map(object({
     deployment_branch_policy = object({
-      protected_branches     = bool
       custom_branch_policies = bool
+      protected_branches     = bool
     })
 
     reviewers = object({
-      users = list(string)
       teams = list(string)
+      users = list(string)
     })
 
     wait_timer = number

--- a/variables.tf
+++ b/variables.tf
@@ -82,15 +82,17 @@ variable "description" {
 
 variable "environments" {
   type = map(object({
+    deployment_branch_policy = object({
+      protected_branches     = bool
+      custom_branch_policies = bool
+    })
+
     reviewers = object({
       users = list(string)
       teams = list(string)
     })
 
-    deployment_branch_policy = object({
-      protected_branches     = bool
-      custom_branch_policies = bool
-    })
+    wait_timer = number
   }))
   default     = {}
   description = "The Github environments that should be configured for reviewers and deployment branch policies"

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,9 @@ variable "description" {
 
 variable "environments" {
   type = map(object({
+    secrets    = map(string)
+    wait_timer = number
+
     deployment_branch_policy = object({
       custom_branch_policies = bool
       protected_branches     = bool
@@ -91,13 +94,9 @@ variable "environments" {
       teams = list(string)
       users = list(string)
     })
-
-    secrets = map(string)
-
-    wait_timer = number
   }))
   default     = {}
-  description = "An optional map with GitHub environments that should be configured for reviewers and deployment branch policies"
+  description = "An optional map with GitHub environments to configure"
 }
 
 variable "gitignore_template" {

--- a/variables.tf
+++ b/variables.tf
@@ -92,10 +92,12 @@ variable "environments" {
       users = list(string)
     })
 
+    secrets = map(string)
+
     wait_timer = number
   }))
   default     = {}
-  description = "The Github environments that should be configured for reviewers and deployment branch policies"
+  description = "An optional map with GitHub environments that should be configured for reviewers and deployment branch policies"
 }
 
 variable "gitignore_template" {

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,22 @@ variable "description" {
   description = "A description for the GitHub repository"
 }
 
+variable "environments" {
+  type = map(object({
+    reviewers = object({
+      users = list(string)
+      teams = list(string)
+    })
+
+    deployment_branch_policy = object({
+      protected_branches     = bool
+      custom_branch_policies = bool
+    })
+  }))
+  default     = {}
+  description = "The Github environments that should be configured for reviewers and deployment branch policies"
+}
+
 variable "gitignore_template" {
   type        = string
   default     = null

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 3.1.0"
+      version = ">= 4.12.0"
     }
   }
 }


### PR DESCRIPTION
This PR introduces support for Github environments allowing to define required reviewers, set branch policies and create environment secrets. Since these resources were only introduced in v4.12.0 of the provider, I've set that as the minimal required version.