### PR TITLE
add allow_auto_merge

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ locals {
 resource "github_repository" "default" {
   name                   = var.name
   description            = var.description
+  allow_auto_merge       = var.allow_auto_merge
   allow_rebase_merge     = var.allow_rebase_merge
   allow_squash_merge     = var.allow_squash_merge
   archived               = var.archived

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "admins" {
   description = "A list of GitHub teams that should have admins access"
 }
 
+variable "allow_auto_merge" {
+  type        = bool
+  default     = false
+  description = "To enable auto merges on the repository"
+}
+
 variable "allow_rebase_merge" {
   type        = bool
   default     = false


### PR DESCRIPTION
This PR adds the [Github automerge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) functionality.

This functionality was added in [v4.17.0 of the GitHub Terraform provider](https://github.com/integrations/terraform-provider-github/pull/923), which is already below the currently required version: [see versions.tf](https://github.com/sanderma/terraform-github-mcaf-repository/blob/allow-auto-merge/versions.tf)

The default setting is `false`, so there should be no braking changes.

```yaml
variable "allow_auto_merge" {
  type        = bool
  default     = false
  description = "To enable auto merges on the repository"
}
```
