### PR TITLE
enhancement: Add maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ No modules.
 | [github_repository_environment.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_file.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_team_repository.admins](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team_repository.maintainers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.readers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.writers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 
@@ -65,6 +66,7 @@ No modules.
 | <a name="input_has_projects"></a> [has\_projects](#input\_has\_projects) | To enable GitHub Projects features on the repository | `bool` | `false` | no |
 | <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | To enable GitHub Wiki features on the repository | `bool` | `false` | no |
 | <a name="input_is_template"></a> [is\_template](#input\_is\_template) | To mark this repository as a template repository | `bool` | `false` | no |
+| <a name="input_maintainers"></a> [maintainers](#input\_maintainers) | A list of GitHub teams that should have maintain access | `list(string)` | `[]` | no |
 | <a name="input_readers"></a> [readers](#input\_readers) | A list of GitHub teams that should have read access | `list(string)` | `[]` | no |
 | <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A list of GitHub repository files that should be created | <pre>map(object({<br>    path    = string<br>    content = string<br>  }))</pre> | `{}` | no |
 | <a name="input_template_repository"></a> [template\_repository](#input\_template\_repository) | The settings of the template repostitory to use on creation | <pre>object({<br>    owner      = string<br>    repository = string<br>  })</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,14 @@ resource "github_team_repository" "admins" {
   team_id    = var.admins[count.index]
 }
 
+resource "github_team_repository" "maintainers" {
+  count = length(var.maintainers)
+
+  permission = "maintain"
+  repository = github_repository.default.name
+  team_id    = var.maintainers[count.index]
+}
+
 resource "github_team_repository" "writers" {
   count = length(var.writers)
 

--- a/variables.tf
+++ b/variables.tf
@@ -154,6 +154,12 @@ variable "is_template" {
   description = "To mark this repository as a template repository"
 }
 
+variable "maintainers" {
+  type        = list(string)
+  default     = []
+  description = "A list of GitHub teams that should have maintain access"
+}
+
 variable "readers" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
This PR adds "maintainers" to the repository access configuration. 

See also: 
- https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization
- https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository.html#permission