### PR TITLE
feat: Use foreach for team permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -123,35 +123,35 @@ resource "github_branch_protection" "default" {
 ################################################################################
 
 resource "github_team_repository" "admins" {
-  count = length(var.admins)
+  for_each = toset(var.admins)
 
   permission = "admin"
   repository = github_repository.default.name
-  team_id    = var.admins[count.index]
+  team_id    = each.key
 }
 
 resource "github_team_repository" "maintainers" {
-  count = length(var.maintainers)
+  for_each = toset(var.maintainers)
 
   permission = "maintain"
   repository = github_repository.default.name
-  team_id    = var.maintainers[count.index]
+  team_id    = each.key
 }
 
 resource "github_team_repository" "writers" {
-  count = length(var.writers)
+  for_each = toset(var.writers)
 
-  team_id    = var.writers[count.index]
   permission = "push"
   repository = github_repository.default.name
+  team_id    = each.key
 }
 
 resource "github_team_repository" "readers" {
-  count = length(var.readers)
+  for_each = toset(var.readers)
 
-  team_id    = var.readers[count.index]
   permission = "pull"
   repository = github_repository.default.name
+  team_id    = each.key
 }
 
 ################################################################################


### PR DESCRIPTION
This PR refactors the way the teams are configured from index based to key based.

Currenty, changes the teams connected to a repository created a lot of recreates due to the nature of using `count`. By changing it to a `foreach`, only the removed/added/altered team is actually being updated. This because the key in the state file is the team ID (Instead of a "random" index). And minor probably, but also saves a few unneeded API calls to Github

_Note: This will one-time recreate all team permissions settings. This is non-destructive but be aware that this happens_