### PR TITLE
feature: Add tag protection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ No modules.
 | [github_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_environment.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_file.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_tag_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_tag_protection) | resource |
 | [github_team_repository.admins](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.maintainers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.readers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
@@ -69,6 +70,7 @@ No modules.
 | <a name="input_maintainers"></a> [maintainers](#input\_maintainers) | A list of GitHub teams that should have maintain access | `list(string)` | `[]` | no |
 | <a name="input_readers"></a> [readers](#input\_readers) | A list of GitHub teams that should have read access | `list(string)` | `[]` | no |
 | <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A list of GitHub repository files that should be created | <pre>map(object({<br>    branch  = optional(string)<br>    path    = string<br>    content = string<br>  }))</pre> | `{}` | no |
+| <a name="input_tag_protection"></a> [tag\_protection](#input\_tag\_protection) | The repository tag protection pattern | `string` | `null` | no |
 | <a name="input_template_repository"></a> [template\_repository](#input\_template\_repository) | The settings of the template repostitory to use on creation | <pre>object({<br>    owner      = string<br>    repository = string<br>  })</pre> | `null` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Set the GitHub repository as public, private or internal | `string` | `"private"` | no |
 | <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | To enable security alerts for vulnerable dependencies | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,13 @@ resource "github_branch_protection" "default" {
   ]
 }
 
+resource "github_repository_tag_protection" "default" {
+  count = var.tag_protection != null ? 1 : 0
+
+  repository = github_repository.default.name
+  pattern    = var.tag_protection
+}
+
 ################################################################################
 # Access
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,12 @@ variable "repository_files" {
   description = "A list of GitHub repository files that should be created"
 }
 
+variable "tag_protection" {
+  type        = string
+  default     = null
+  description = "The repository tag protection pattern"
+}
+
 variable "template_repository" {
   type = object({
     owner      = string


### PR DESCRIPTION
This PR adds support to configure the Tag Protection.

**Links:**
- https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_tag_protection
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules