### PR TITLE
fix: Support managing files in non-default branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ No modules.
 | <a name="input_is_template"></a> [is\_template](#input\_is\_template) | To mark this repository as a template repository | `bool` | `false` | no |
 | <a name="input_maintainers"></a> [maintainers](#input\_maintainers) | A list of GitHub teams that should have maintain access | `list(string)` | `[]` | no |
 | <a name="input_readers"></a> [readers](#input\_readers) | A list of GitHub teams that should have read access | `list(string)` | `[]` | no |
-| <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A list of GitHub repository files that should be created | <pre>map(object({<br>    path    = string<br>    content = string<br>  }))</pre> | `{}` | no |
+| <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A list of GitHub repository files that should be created | <pre>map(object({<br>    branch  = optional(string)<br>    path    = string<br>    content = string<br>  }))</pre> | `{}` | no |
 | <a name="input_template_repository"></a> [template\_repository](#input\_template\_repository) | The settings of the template repostitory to use on creation | <pre>object({<br>    owner      = string<br>    repository = string<br>  })</pre> | `null` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Set the GitHub repository as public, private or internal | `string` | `"private"` | no |
 | <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | To enable security alerts for vulnerable dependencies | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,7 @@ resource "github_actions_variable" "action_variables" {
 resource "github_repository_file" "default" {
   for_each = var.repository_files
 
-  branch              = local.default_branch
+  branch              = coalesce(each.value.branch, local.default_branch)
   content             = each.value.content
   file                = each.value.path
   overwrite_on_create = true

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,7 @@ variable "readers" {
 
 variable "repository_files" {
   type = map(object({
+    branch  = optional(string)
     path    = string
     content = string
   }))


### PR DESCRIPTION
Small fix to allow us to specify a branch when using the
`github_repository_file` resource and not be confined to the only the
default branch.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
