### PR TITLE
bug: remove duplicate restrict_pushes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,15 +74,6 @@ resource "github_branch_protection" "default" {
   repository_id          = github_repository.default.name
   require_signed_commits = each.value.branch_protection != null ? each.value.branch_protection.require_signed_commits : var.default_branch_protection.require_signed_commits
 
-  dynamic "restrict_pushes" {
-    for_each = try(each.value.branch_protection.restrict_pushes, null) != null ? { create : true } : {}
-
-    content {
-      blocks_creations = each.value.branch_protection != null ? try(each.value.branch_protection.restrict_pushes.blocks_creations, null) : try(var.default_branch_protection.restrict_pushes.blocks_creations, null)
-      push_allowances  = each.value.branch_protection != null ? try(each.value.branch_protection.restrict_pushes.push_allowances, null) : try(var.default_branch_protection.restrict_pushes.push_allowances, null)
-    }
-  }
-
   dynamic "required_pull_request_reviews" {
     for_each = try(each.value.branch_protection.required_reviews, null) != null || var.default_branch_protection.required_reviews != null ? { create : true } : {}
 

--- a/main.tf
+++ b/main.tf
@@ -94,10 +94,6 @@ resource "github_branch_protection" "default" {
     }
   }
 
-  depends_on = [
-    github_branch.default,
-  ]
-
   dynamic "restrict_pushes" {
     for_each = try(each.value.branch_protection.restrict_pushes, null) != null || var.default_branch_protection.restrict_pushes != null ? { create : true } : {}
 
@@ -106,6 +102,10 @@ resource "github_branch_protection" "default" {
       push_allowances  = each.value.branch_protection != null ? try(each.value.branch_protection.restrict_pushes.push_allowances, null) : try(var.default_branch_protection.restrict_pushes.push_allowances, null)
     }
   }
+
+  depends_on = [
+    github_branch.default,
+  ]
 }
 
 resource "github_repository_tag_protection" "default" {


### PR DESCRIPTION
The `restrict_pushes` is defined twice:

`Error: error multiple restrict_pushes declarations`

This PR removes one of the 2

See line 110: https://github.com/schubergphilis/terraform-github-mcaf-repository/pull/66/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL110