### PR TITLE
documentation: Correct use_branch_protection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module "mcaf-repository" {
 
   branches = {
     "develop" = {
-      branch_protection = { use_branch_protection = false }
+      use_branch_protection = false
     }
   }
 }


### PR DESCRIPTION
This PR corrects the example on how to disable branch protection