### PR TITLE
feat: Add Squash merge commit message/title

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ No modules.
 | <a name="input_maintainers"></a> [maintainers](#input\_maintainers) | A list of GitHub teams that should have maintain access | `list(string)` | `[]` | no |
 | <a name="input_readers"></a> [readers](#input\_readers) | A list of GitHub teams that should have read access | `list(string)` | `[]` | no |
 | <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A list of GitHub repository files that should be created | <pre>map(object({<br>    branch  = optional(string)<br>    path    = string<br>    content = string<br>  }))</pre> | `{}` | no |
+| <a name="input_squash_merge_commit_message"></a> [squash\_merge\_commit\_message](#input\_squash\_merge\_commit\_message) | The default commit message for squash merges | `string` | `"COMMIT_MESSAGES"` | no |
+| <a name="input_squash_merge_commit_title"></a> [squash\_merge\_commit\_title](#input\_squash\_merge\_commit\_title) | The default commit title for squash merges | `string` | `"COMMIT_OR_PR_TITLE"` | no |
 | <a name="input_tag_protection"></a> [tag\_protection](#input\_tag\_protection) | The repository tag protection pattern | `string` | `null` | no |
 | <a name="input_template_repository"></a> [template\_repository](#input\_template\_repository) | The settings of the template repostitory to use on creation | <pre>object({<br>    owner      = string<br>    repository = string<br>  })</pre> | `null` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Set the GitHub repository as public, private or internal | `string` | `"private"` | no |

--- a/main.tf
+++ b/main.tf
@@ -12,23 +12,25 @@ locals {
 
 #tfsec:ignore:github-repositories-vulnerability-alerts
 resource "github_repository" "default" {
-  allow_auto_merge       = var.allow_auto_merge
-  allow_rebase_merge     = var.allow_rebase_merge
-  allow_squash_merge     = var.allow_squash_merge
-  archived               = var.archived
-  auto_init              = var.auto_init
-  delete_branch_on_merge = var.delete_branch_on_merge
-  description            = var.description
-  gitignore_template     = var.gitignore_template
-  has_downloads          = var.has_downloads
-  has_issues             = var.has_issues
-  has_projects           = var.has_projects
-  has_wiki               = var.has_wiki
-  homepage_url           = var.homepage_url
-  is_template            = var.is_template
-  name                   = var.name
-  visibility             = var.visibility
-  vulnerability_alerts   = var.vulnerability_alerts
+  allow_auto_merge            = var.allow_auto_merge
+  allow_rebase_merge          = var.allow_rebase_merge
+  allow_squash_merge          = var.allow_squash_merge
+  archived                    = var.archived
+  auto_init                   = var.auto_init
+  delete_branch_on_merge      = var.delete_branch_on_merge
+  description                 = var.description
+  gitignore_template          = var.gitignore_template
+  has_downloads               = var.has_downloads
+  has_issues                  = var.has_issues
+  has_projects                = var.has_projects
+  has_wiki                    = var.has_wiki
+  homepage_url                = var.homepage_url
+  is_template                 = var.is_template
+  name                        = var.name
+  squash_merge_commit_message = var.allow_squash_merge ? var.squash_merge_commit_message : null
+  squash_merge_commit_title   = var.allow_squash_merge ? var.squash_merge_commit_title : null
+  visibility                  = var.visibility
+  vulnerability_alerts        = var.vulnerability_alerts
 
   dynamic "template" {
     for_each = var.template_repository != null ? { create = true } : {}

--- a/variables.tf
+++ b/variables.tf
@@ -228,6 +228,28 @@ variable "repository_files" {
   description = "A list of GitHub repository files that should be created"
 }
 
+variable "squash_merge_commit_message" {
+  type        = string
+  default     = "COMMIT_MESSAGES"
+  description = "The default commit message for squash merges"
+
+  validation {
+    condition     = can(regex("^(PR_BODY|COMMIT_MESSAGES|BLANK)$", var.squash_merge_commit_message))
+    error_message = "The value of the variable 'squash_merge_commit_message' must be one of 'PR_BODY', 'COMMIT_MESSAGES' or 'BLANK'"
+  }
+}
+
+variable "squash_merge_commit_title" {
+  type        = string
+  default     = "COMMIT_OR_PR_TITLE"
+  description = "The default commit title for squash merges"
+
+  validation {
+    condition     = can(regex("^(PR_TITLE|COMMIT_OR_PR_TITLE)$", var.squash_merge_commit_title))
+    error_message = "The value of the variable 'squash_merge_commit_title' must be one of 'PR_TITLE' or 'COMMIT_OR_PR_TITLE'"
+  }
+}
+
 variable "tag_protection" {
   type        = string
   default     = null


### PR DESCRIPTION
This PR adds the configuration of the squash commit message/title. Will be specified when `allow_squash_merge` is true.

Tested this out, and the commit title/message have a default value, so configured this explicitly for simplicity:

```hcl
  ~ resource "github_repository" "default" {
      ~ allow_squash_merge          = false -> true
      ~ squash_merge_commit_message = "COMMIT_MESSAGES" -> "BLANK"
      ~ squash_merge_commit_title   = "COMMIT_OR_PR_TITLE" -> "PR_TITLE"
        # (33 unchanged attributes hidden)
    }
```

Links:
- https://github.blog/changelog/2022-08-23-new-options-for-controlling-the-default-commit-message-when-merging-a-pull-request/
- https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository