### PR TITLE
fix: Refactor tag protection resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ No modules.
 | [github_repository_environment.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment_deployment_policy.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_file.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
-| [github_repository_tag_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_tag_protection) | resource |
+| [github_repository_ruleset.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
 | [github_team_repository.admins](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.maintainers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.readers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |

--- a/main.tf
+++ b/main.tf
@@ -108,11 +108,35 @@ resource "github_branch_protection" "default" {
   ]
 }
 
-resource "github_repository_tag_protection" "default" {
-  count = var.tag_protection != null ? 1 : 0
+resource "github_repository_ruleset" "default" {
+  count       = var.tag_protection != null ? 1 : 0
+  name        = "Tag protection"
+  repository  = github_repository.default.name
+  target      = "tag"
+  enforcement = "active"
 
-  repository = github_repository.default.name
-  pattern    = var.tag_protection
+  bypass_actors {
+    actor_id    = 5 # Repository admins
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+
+  bypass_actors {
+    actor_id    = 1 # Organization admins
+    actor_type  = "OrganizationAdmin"
+    bypass_mode = "always"
+  }
+
+  rules {
+    creation = true
+    update   = true
+    deletion = true
+
+    tag_name_pattern {
+      operator = "regex"
+      pattern  = var.tag_protection
+    }
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
This PR refactors the Tag Protection resources.

The old tag protection is deprecated and is replaced with Rulesets:

```Error: POST https://api.github.com/repos/connectedbrewery/nldevoc-sandbox-wspaargaren/tags/protection: 410 This is a scheduled brownout of the tag protections API. Tag protections will be fully deprecated on 2024-08-30. At that point, this API endpoint will be removed. Please use tag rulesets instead. []```

This PR changes the resource from `github_repository_tag_protection` to `github_repository_ruleset` while keeping the functionality intact. The refactor is based on the `export to ruleset` outcome from Github itself:

<img width="802" alt="image" src="https://github.com/user-attachments/assets/5f853bf8-ada4-45ba-9db6-983e5a78ce70">

On purpose made it a 1-on-1 refactor without implementing any specific ruleset features so this can be a patch version. Since it currently is completely broken this allows for a smooth update.

See also: https://github.blog/changelog/2024-05-29-sunset-notice-tag-protections/