### PR TITLE
fix: Fix tag protection refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ No modules.
 | [github_repository_environment.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment_deployment_policy.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_file.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
-| [github_repository_tag_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_tag_protection) | resource |
+| [github_repository_ruleset.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
 | [github_team_repository.admins](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.maintainers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.readers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |

--- a/main.tf
+++ b/main.tf
@@ -127,15 +127,17 @@ resource "github_repository_ruleset" "default" {
     bypass_mode = "always"
   }
 
+  conditions {
+    ref_name {
+      exclude = []
+      include = ["refs/tags/${var.tag_protection}"]
+    }
+  }
+
   rules {
     creation = true
     update   = true
     deletion = true
-
-    tag_name_pattern {
-      operator = "regex"
-      pattern  = var.tag_protection
-    }
   }
 }
 


### PR DESCRIPTION
This PR fixes the tag protection refactor made in the [previous PR](https://github.com/schubergphilis/terraform-github-mcaf-repository/pull/69).

The pattern is actually just a `condition`, not the name pattern. That is apparantly something else:
![image](https://github.com/user-attachments/assets/b52fb358-4ba5-46cf-8de9-1f982d323c0e)


So tested a bit more with a test repository and this is the actual configuration to make it work the same as the "old" tag protection regex