### PR TITLE
feat: Support unmanaged files

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -233,6 +233,7 @@ variable "repository_files" {
     branch  = optional(string)
     path    = string
     content = string
+    managed = optional(bool, true)
   }))
   default     = {}
   description = "A list of GitHub repository files that should be created"


### PR DESCRIPTION
**:hammer_and_wrench: Summary**

Add a `managed` field to the `repository_files` variables which defaults to true to keep original behaviour. Setting to false will let Terraform create the file but no longer manage it's contents.

**:rocket: Motivation**

Sometimes you want to template a repository where you need interpolation so creating from a template repository does not work. The content of these skeleton files shouldn't be managed by Terraform, they're intended to be written once and then updated outside of Terraform.

**:pencil: Additional Information**

This should be a non-breaking change as we add a field to the `repository_files` variable that defaults to the original behaviour and include a `moved` block to migrate any existing files from `github_repository_file.default` to `github_repository_file.managed`.

