### PR TITLE
feat!: Update `github_repository` fields and behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Terraform module to create and manage a GitHub repository.
 
+## Adding a license or `.gitignore` template
+
+Take care when configuring either `var.license_template` or `var.gitignore_template` as the values are case sensitive. See [here for a list of supported licenses](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses) or [here for a list of supported gitignore templates](https://github.com/github/gitignore) - to use either, provide the file name without the extension, e.g. `mit` or `Terraform` respectively.
+
+Setting one of these templates can only be done during creation of the repository. If you want to add a `LICENSE` or `.gitignore` file after repository creation, you'll need to do it like any other file.
+
 ## Creating branches
 
 Additional branches can be created and configured using `var.branches`. Any branches created here are in addition to the default branch (`var.default_branch`).

--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ No modules.
 | <a name="input_actions_access_level"></a> [actions\_access\_level](#input\_actions\_access\_level) | Control how this repository is used by GitHub Actions workflows in other repositories | `string` | `null` | no |
 | <a name="input_actions_secrets"></a> [actions\_secrets](#input\_actions\_secrets) | An optional map with GitHub action secrets | `map(string)` | `{}` | no |
 | <a name="input_actions_variables"></a> [actions\_variables](#input\_actions\_variables) | An optional map with GitHub Actions variables | `map(string)` | `{}` | no |
-| <a name="input_allow_auto_merge"></a> [allow\_auto\_merge](#input\_allow\_auto\_merge) | Enable to allow auto-merging pull requests on the repository | `bool` | `false` | no |
-| <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | To enable rebase merges on the repository | `bool` | `false` | no |
-| <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | To enable squash merges on the repository | `bool` | `false` | no |
+| <a name="input_allow_auto_merge"></a> [allow\_auto\_merge](#input\_allow\_auto\_merge) | Enable allow auto-merging pull requests on the repository | `bool` | `true` | no |
+| <a name="input_allow_merge_commit"></a> [allow\_merge\_commit](#input\_allow\_merge\_commit) | Enable merge commits on the repository | `bool` | `false` | no |
+| <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | Enable rebase merges on the repository | `bool` | `false` | no |
+| <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | Enable squash merges on the repository | `bool` | `true` | no |
+| <a name="input_allow_update_branch"></a> [allow\_update\_branch](#input\_allow\_update\_branch) | Enable to allow suggestions to update pull request branches | `bool` | `true` | no |
 | <a name="input_archive_on_destroy"></a> [archive\_on\_destroy](#input\_archive\_on\_destroy) | Set to true to archive the repository instead of deleting on destroy | `bool` | `false` | no |
 | <a name="input_archived"></a> [archived](#input\_archived) | Specifies if the repository should be archived | `bool` | `false` | no |
 | <a name="input_auto_init"></a> [auto\_init](#input\_auto\_init) | Disable to not produce an initial commit in the repository | `bool` | `true` | no |
@@ -193,11 +195,15 @@ No modules.
 | <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | To enable GitHub Wiki features on the repository | `bool` | `false` | no |
 | <a name="input_homepage_url"></a> [homepage\_url](#input\_homepage\_url) | URL of a page describing the project | `string` | `null` | no |
 | <a name="input_is_template"></a> [is\_template](#input\_is\_template) | To mark this repository as a template repository | `bool` | `false` | no |
+| <a name="input_license_template"></a> [license\_template](#input\_license\_template) | The name of the (case sensitive) license template to use | `string` | `null` | no |
+| <a name="input_merge_commit_message"></a> [merge\_commit\_message](#input\_merge\_commit\_message) | The default commit message for merge commits | `string` | `"PR_BODY"` | no |
+| <a name="input_merge_commit_title"></a> [merge\_commit\_title](#input\_merge\_commit\_title) | The default commit title for merge commits | `string` | `"PR_TITLE"` | no |
 | <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A list of GitHub repository files that should be created | <pre>map(object({<br/>    branch  = optional(string)<br/>    path    = string<br/>    content = string<br/>    managed = optional(bool, true)<br/>  }))</pre> | `{}` | no |
 | <a name="input_squash_merge_commit_message"></a> [squash\_merge\_commit\_message](#input\_squash\_merge\_commit\_message) | The default commit message for squash merges | `string` | `"COMMIT_MESSAGES"` | no |
-| <a name="input_squash_merge_commit_title"></a> [squash\_merge\_commit\_title](#input\_squash\_merge\_commit\_title) | The default commit title for squash merges | `string` | `"COMMIT_OR_PR_TITLE"` | no |
+| <a name="input_squash_merge_commit_title"></a> [squash\_merge\_commit\_title](#input\_squash\_merge\_commit\_title) | The default commit title for squash merges | `string` | `"PR_TITLE"` | no |
 | <a name="input_tag_protection"></a> [tag\_protection](#input\_tag\_protection) | The repository tag protection pattern | `string` | `null` | no |
 | <a name="input_template_repository"></a> [template\_repository](#input\_template\_repository) | The settings of the template repostitory to use on creation | <pre>object({<br/>    owner      = string<br/>    repository = string<br/>  })</pre> | `null` | no |
+| <a name="input_topics"></a> [topics](#input\_topics) | A list of topics to set on the repository | `list(string)` | `[]` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Set the GitHub repository as public, private or internal | `string` | `"private"` | no |
 | <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | To enable security alerts for vulnerable dependencies | `bool` | `false` | no |
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,14 @@ This document captures breaking changes.
 
 ## Upgrading to v2.0.0
 
+### Merging pull requests
+
+Starting from v2.0.0, the default behavior is to support only squash merging. This approach combines all commits from the head branch into a single commit on the base branch. It allows committers to make multiple commits while addressing pull request feedback and keeps the default branch history clean by squashing all changes into one commit upon merge. Additionally, the pull request title is used as the commit message title, which ensures consistency and supports workflows that rely on conventional commit messages.
+
+To enable previous behaviour, set `var.allow_merge_commit = true` and `var.allow_squash_merge = false`.
+
+### Migrating to `var.access`
+
 To fix a bug where group IDs are not known at plan time, `var.access` has been added to replace the `var.admins`, `var.maintainers`, `var.readers` and `var.writers`. This allows specifying the team name as the map key and the desired access level as the value.
 
 To migrate, map the old variables to the new variable:

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,12 @@ locals {
 
 #tfsec:ignore:github-repositories-vulnerability-alerts
 resource "github_repository" "default" {
+  name                        = var.name
   allow_auto_merge            = var.allow_auto_merge
+  allow_merge_commit          = var.allow_merge_commit
   allow_rebase_merge          = var.allow_rebase_merge
   allow_squash_merge          = var.allow_squash_merge
+  allow_update_branch         = var.allow_update_branch
   archive_on_destroy          = var.archive_on_destroy
   archived                    = var.archived
   auto_init                   = var.auto_init
@@ -27,9 +30,12 @@ resource "github_repository" "default" {
   has_wiki                    = var.has_wiki
   homepage_url                = var.homepage_url
   is_template                 = var.is_template
-  name                        = var.name
+  license_template            = var.license_template
+  merge_commit_message        = var.allow_merge_commit ? var.merge_commit_message : null
+  merge_commit_title          = var.allow_merge_commit ? var.merge_commit_title : null
   squash_merge_commit_message = var.allow_squash_merge ? var.squash_merge_commit_message : null
   squash_merge_commit_title   = var.allow_squash_merge ? var.squash_merge_commit_title : null
+  topics                      = var.topics
   visibility                  = var.visibility
   vulnerability_alerts        = var.vulnerability_alerts
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,15 @@ variable "access" {
   }
 }
 
-variable "name" {
+variable "actions_access_level" {
   type        = string
-  description = "The name of the repository"
+  default     = null
+  description = "Control how this repository is used by GitHub Actions workflows in other repositories"
+
+  validation {
+    condition     = var.actions_access_level == null || can(regex("^(none|user|organization|enterprise)$", var.actions_access_level))
+    error_message = "The value of the variable 'actions_access_level' must be one of 'none', 'user', 'organization' or 'enterprise'"
+  }
 }
 
 variable "actions_secrets" {
@@ -23,25 +29,37 @@ variable "actions_secrets" {
 variable "actions_variables" {
   type        = map(string)
   default     = {}
-  description = " An optional map with GitHub Actions variables"
+  description = "An optional map with GitHub Actions variables"
 }
 
 variable "allow_auto_merge" {
   type        = bool
+  default     = true
+  description = "Enable allow auto-merging pull requests on the repository"
+}
+
+variable "allow_merge_commit" {
+  type        = bool
   default     = false
-  description = "Enable to allow auto-merging pull requests on the repository"
+  description = "Enable merge commits on the repository"
 }
 
 variable "allow_rebase_merge" {
   type        = bool
   default     = false
-  description = "To enable rebase merges on the repository"
+  description = "Enable rebase merges on the repository"
 }
 
 variable "allow_squash_merge" {
   type        = bool
-  default     = false
-  description = "To enable squash merges on the repository"
+  default     = true
+  description = "Enable squash merges on the repository"
+}
+
+variable "allow_update_branch" {
+  type        = bool
+  default     = true
+  description = "Enable to allow suggestions to update pull request branches"
 }
 
 variable "archive_on_destroy" {
@@ -221,6 +239,39 @@ variable "homepage_url" {
   description = "URL of a page describing the project"
 }
 
+variable "license_template" {
+  type        = string
+  default     = null
+  description = "The name of the (case sensitive) license template to use"
+}
+
+variable "merge_commit_message" {
+  type        = string
+  default     = "PR_BODY"
+  description = "The default commit message for merge commits"
+
+  validation {
+    condition     = can(regex("^(PR_BODY|PR_TITLE|BLANK)$", var.merge_commit_message))
+    error_message = "The value of the variable 'merge_commit_message' must be one of 'PR_BODY', 'PR_TITLE' or 'BLANK'"
+  }
+}
+
+variable "merge_commit_title" {
+  type        = string
+  default     = "PR_TITLE"
+  description = "The default commit title for merge commits"
+
+  validation {
+    condition     = can(regex("^(PR_TITLE|MERGE_MESSAGE)$", var.merge_commit_title))
+    error_message = "The value of the variable 'merge_commit_title' must be one of 'PR_TITLE' or 'MERGE_MESSAGE'"
+  }
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the repository"
+}
+
 variable "repository_files" {
   type = map(object({
     branch  = optional(string)
@@ -245,7 +296,7 @@ variable "squash_merge_commit_message" {
 
 variable "squash_merge_commit_title" {
   type        = string
-  default     = "COMMIT_OR_PR_TITLE"
+  default     = "PR_TITLE"
   description = "The default commit title for squash merges"
 
   validation {
@@ -269,6 +320,12 @@ variable "template_repository" {
   description = "The settings of the template repostitory to use on creation"
 }
 
+variable "topics" {
+  type        = list(string)
+  default     = []
+  description = "A list of topics to set on the repository"
+}
+
 variable "visibility" {
   type        = string
   default     = "private"
@@ -279,15 +336,4 @@ variable "vulnerability_alerts" {
   type        = bool
   default     = false
   description = "To enable security alerts for vulnerable dependencies"
-}
-
-variable "actions_access_level" {
-  type        = string
-  default     = null
-  description = "Control how this repository is used by GitHub Actions workflows in other repositories"
-
-  validation {
-    condition     = var.actions_access_level == null || can(regex("^(none|user|organization|enterprise)$", var.actions_access_level))
-    error_message = "The value of the variable 'actions_access_level' must be one of 'none', 'user', 'organization' or 'enterprise'"
-  }
 }


### PR DESCRIPTION
**:hammer_and_wrench: Summary**

Adding some missing functionality

- Added `var.allow_merge_commit` to provide a way to disable merge commits
- Added `var.merge_commit_message` and `var.merge_commit_title` to custom default message and title when using merge commits
- Added `var.allow_update_branch` to provide a way to suggest updating pull request branches
- Added `var.license_template` to provide a way to configure a `LICENSE` file at repository creation time
- Added `var.topics` to set a list of topics on the repository

And changing some default behaviour:

- Make squash merge the only merge strategy out the box: users can set `var.allow_merge_commit` and `var.allow_rebase_merge` to allow all possible merge options
- `var.allow_update_branch` is set to true to present a "update branch" option in the pull request when there are new changes available in the base branch

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
