### PR TITLE
fix: Set `var.vulnerability_alerts` default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ No modules.
 | <a name="input_template_repository"></a> [template\_repository](#input\_template\_repository) | The settings of the template repostitory to use on creation | <pre>object({<br/>    owner      = string<br/>    repository = string<br/>  })</pre> | `null` | no |
 | <a name="input_topics"></a> [topics](#input\_topics) | A list of topics to set on the repository | `list(string)` | `[]` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Set the GitHub repository as public, private or internal | `string` | `"private"` | no |
-| <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | To enable security alerts for vulnerable dependencies | `bool` | `false` | no |
+| <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | Set to true to enable security alerts for vulnerable dependencies | `bool` | `true` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -334,6 +334,6 @@ variable "visibility" {
 
 variable "vulnerability_alerts" {
   type        = bool
-  default     = false
-  description = "To enable security alerts for vulnerable dependencies"
+  default     = true
+  description = "Set to true to enable security alerts for vulnerable dependencies"
 }


### PR DESCRIPTION
## **:hammer_and_wrench: Summary**

This pull request updates the default value and description of the `vulnerability_alerts` variable in the `variables.tf` file to improve security and clarity.

**Changes to `variables.tf`:**

* Updated the `vulnerability_alerts` variable:
  - Changed the default value from `false` to `true` to enable security alerts for vulnerable dependencies by default.
  - Revised the description for better clarity: "Set to true to enable security alerts for vulnerable dependencies."

## **:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->

GitHub enables the alerts on public repos but disables them on private repos by default.

As we often create private repositories inside an organisation, we should default to `true` and let people opt out if they are using a free org or personal namespace.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>