### PR TITLE
fix: Ensure you do not enable dependabot when your vulnerability alerts are not

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The module will use a data resource to look up the team ID and assign the team t
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -224,4 +224,4 @@ No modules.
 
 ## Licensing
 
-1`00% Open Source and licensed under the Apache License Version 2.0. See [LICENSE](https://github.com/schubergphilis/terraform-github-mcaf-repository/blob/master/LICENSE) for full details.`
+100% Open Source and licensed under the Apache License Version 2.0. See [LICENSE](https://github.com/schubergphilis/terraform-github-mcaf-repository/blob/master/LICENSE) for full details.`

--- a/README.md
+++ b/README.md
@@ -224,4 +224,4 @@ No modules.
 
 ## Licensing
 
-100% Open Source and licensed under the Apache License Version 2.0. See [LICENSE](https://github.com/schubergphilis/terraform-github-mcaf-repository/blob/master/LICENSE) for full details.
+1`00% Open Source and licensed under the Apache License Version 2.0. See [LICENSE](https://github.com/schubergphilis/terraform-github-mcaf-repository/blob/master/LICENSE) for full details.`

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "github_repository_dependabot_security_updates" "default" {
 resource "github_dependabot_secret" "plaintext" {
   for_each = var.dependabot_plaintext_secrets
 
-  repository      = github_repository_dependabot_security_updates.default.repository
+  repository      = github_repository_dependabot_security_updates.default[0].repository
   secret_name     = each.key
   plaintext_value = each.value
 }
@@ -75,7 +75,7 @@ resource "github_dependabot_secret" "plaintext" {
 resource "github_dependabot_secret" "encrypted" {
   for_each = var.dependabot_encrypted_secrets
 
-  repository      = github_repository_dependabot_security_updates.default.repository
+  repository      = github_repository_dependabot_security_updates.default[0].repository
   secret_name     = each.key
   encrypted_value = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,11 @@ resource "github_repository" "default" {
   }
 }
 
+moved {
+  from = github_repository_dependabot_security_updates.default
+  to = github_repository_dependabot_security_updates.default[0]
+}
+
 # Configure Dependabot security updates for the repository.
 resource "github_repository_dependabot_security_updates" "default" {
   count      = var.vulnerability_alerts ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "github_repository" "default" {
 
 # Configure Dependabot security updates for the repository.
 resource "github_repository_dependabot_security_updates" "default" {
+  count      = var.vulnerability_alerts ? 1 : 0
   repository = github_repository.default.name
   enabled    = var.dependabot_enabled
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   required_providers {
     github = {

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,10 @@ variable "dependabot_enabled" {
   type        = bool
   default     = false
   description = "Set to true to enable Dependabot alerts and security updates"
+  validation   {
+    condition     = (!var.dependabot_enabled) || var.vulnerability_alerts
+    error_message = "Vulnerability alerts need to be enabled to enable Dependabot"
+  }
 }
 
 variable "dependabot_plaintext_secrets" {


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Github fails when you configure dependabot (either true or false) when vulnerability alerting is not enabled

**:pencil: Additional Information**
- Add validation
- Make dependabot resource a count so it can be disabled