### PR TITLE
feat: Add `var.merge_strategy` to select merge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ The module will use a data resource to look up the team ID and assign the team t
 > }
 > ```
 
+## Selecting a merge strategy
+
+By default, the module will enable squash merges and disable merge commits and rebase merges. You can change this by setting the `allow_merge_commit`, `allow_rebase_merge` and `allow_squash_merge` variables to `true` or `false`.
+
+To more easily select a single strategy, you can set the `merge_strategy` variable to one of the following values:
+
+* `merge`
+* `rebase`
+* `squash`
+
+Using `merge_strategy` will override the above variables.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ No modules.
 | <a name="input_actions_secrets"></a> [actions\_secrets](#input\_actions\_secrets) | An optional map with GitHub action secrets | `map(string)` | `{}` | no |
 | <a name="input_actions_variables"></a> [actions\_variables](#input\_actions\_variables) | An optional map with GitHub Actions variables | `map(string)` | `{}` | no |
 | <a name="input_allow_auto_merge"></a> [allow\_auto\_merge](#input\_allow\_auto\_merge) | Enable allow auto-merging pull requests on the repository | `bool` | `true` | no |
-| <a name="input_allow_merge_commit"></a> [allow\_merge\_commit](#input\_allow\_merge\_commit) | Enable merge commits on the repository | `bool` | `false` | no |
-| <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | Enable rebase merges on the repository | `bool` | `false` | no |
+| <a name="input_allow_merge_commit"></a> [allow\_merge\_commit](#input\_allow\_merge\_commit) | Enable merge commits on the repository | `bool` | `true` | no |
+| <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | Enable rebase merges on the repository | `bool` | `true` | no |
 | <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | Enable squash merges on the repository | `bool` | `true` | no |
 | <a name="input_allow_update_branch"></a> [allow\_update\_branch](#input\_allow\_update\_branch) | Enable to allow suggestions to update pull request branches | `bool` | `true` | no |
 | <a name="input_archive_on_destroy"></a> [archive\_on\_destroy](#input\_archive\_on\_destroy) | Set to true to archive the repository instead of deleting on destroy | `bool` | `false` | no |
@@ -216,6 +216,7 @@ No modules.
 | <a name="input_license_template"></a> [license\_template](#input\_license\_template) | The name of the (case sensitive) license template to use | `string` | `null` | no |
 | <a name="input_merge_commit_message"></a> [merge\_commit\_message](#input\_merge\_commit\_message) | The default commit message for merge commits | `string` | `"PR_BODY"` | no |
 | <a name="input_merge_commit_title"></a> [merge\_commit\_title](#input\_merge\_commit\_title) | The default commit title for merge commits | `string` | `"PR_TITLE"` | no |
+| <a name="input_merge_strategy"></a> [merge\_strategy](#input\_merge\_strategy) | The merge strategy to use for pull requests | `string` | `null` | no |
 | <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A list of GitHub repository files that should be created | <pre>map(object({<br/>    branch  = optional(string)<br/>    path    = string<br/>    content = string<br/>    managed = optional(bool, true)<br/>  }))</pre> | `{}` | no |
 | <a name="input_squash_merge_commit_message"></a> [squash\_merge\_commit\_message](#input\_squash\_merge\_commit\_message) | The default commit message for squash merges | `string` | `"COMMIT_MESSAGES"` | no |
 | <a name="input_squash_merge_commit_title"></a> [squash\_merge\_commit\_title](#input\_squash\_merge\_commit\_title) | The default commit title for squash merges | `string` | `"PR_TITLE"` | no |

--- a/examples/merge-strategy/main.tf
+++ b/examples/merge-strategy/main.tf
@@ -1,0 +1,9 @@
+module "repo" {
+  #checkov:skip=CKV_GIT_4:Ensure GitHub Actions secrets are encrypted - n/a for the example
+  #checkov:skip=CKV_GIT_5:Pull requests should require at least 2 approvals - n/a for the example
+
+  source = "../.."
+
+  name           = "basic"
+  merge_strategy = "squash"
+}

--- a/examples/merge-strategy/terraform.tf
+++ b/examples/merge-strategy/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+  required_version = ">= 1.3.0"
+}

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,11 @@ locals {
     { (var.default_branch) = { branch_protection = null, use_branch_protection = true } },
     var.branches,
   )
+
+  # Use var.merge_strategy value if set, otherwise fallback to the variable value.
+  allow_merge_commit = var.merge_strategy != null ? var.merge_strategy == "merge" : var.allow_merge_commit
+  allow_rebase_merge = var.merge_strategy != null ? var.merge_strategy == "rebase" : var.allow_rebase_merge
+  allow_squash_merge = var.merge_strategy != null ? var.merge_strategy == "squash" : var.allow_squash_merge
 }
 
 ################################################################################
@@ -14,9 +19,9 @@ locals {
 resource "github_repository" "default" {
   name                        = var.name
   allow_auto_merge            = var.allow_auto_merge
-  allow_merge_commit          = var.allow_merge_commit
-  allow_rebase_merge          = var.allow_rebase_merge
-  allow_squash_merge          = var.allow_squash_merge
+  allow_merge_commit          = local.allow_merge_commit
+  allow_rebase_merge          = local.allow_rebase_merge
+  allow_squash_merge          = local.allow_squash_merge
   allow_update_branch         = var.allow_update_branch
   archive_on_destroy          = var.archive_on_destroy
   archived                    = var.archived
@@ -31,10 +36,10 @@ resource "github_repository" "default" {
   homepage_url                = var.homepage_url
   is_template                 = var.is_template
   license_template            = var.license_template
-  merge_commit_message        = var.allow_merge_commit ? var.merge_commit_message : null
-  merge_commit_title          = var.allow_merge_commit ? var.merge_commit_title : null
-  squash_merge_commit_message = var.allow_squash_merge ? var.squash_merge_commit_message : null
-  squash_merge_commit_title   = var.allow_squash_merge ? var.squash_merge_commit_title : null
+  merge_commit_message        = local.allow_merge_commit ? var.merge_commit_message : null
+  merge_commit_title          = local.allow_merge_commit ? var.merge_commit_title : null
+  squash_merge_commit_message = local.allow_squash_merge ? var.squash_merge_commit_message : null
+  squash_merge_commit_title   = local.allow_squash_merge ? var.squash_merge_commit_title : null
   topics                      = var.topics
   visibility                  = var.visibility
   vulnerability_alerts        = var.vulnerability_alerts

--- a/tests/basic.tftest.hcl
+++ b/tests/basic.tftest.hcl
@@ -66,3 +66,150 @@ run "basic" {
     error_message = "Branch protection required_linear_history does not match"
   }
 }
+
+# var.merge_strategy is not set by default, the default behavior is to enable all merge strategies.
+run "merge_strategy_null" {
+  variables {
+    name           = "merge-strategy-null-${run.setup.random_string}"
+    merge_strategy = null
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  assert {
+    condition     = resource.github_repository.default.name == "merge-strategy-null-${run.setup.random_string}"
+    error_message = "Name does not match"
+  }
+
+  // Validate all merge strategies are enabled by default
+  assert {
+    condition     = resource.github_repository.default.allow_merge_commit == true
+    error_message = "Merge commit strategy should be true"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_squash_merge == true
+    error_message = "Squash merge strategy shuld be true"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_rebase_merge == true
+    error_message = "Rebase merge strategy shuld be true"
+  }
+}
+
+run "merge_strategy_merge" {
+  variables {
+    name           = "merge-strategy-merge-${run.setup.random_string}"
+    merge_strategy = "merge"
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  assert {
+    condition     = resource.github_repository.default.name == "merge-strategy-merge-${run.setup.random_string}"
+    error_message = "Name does not match"
+  }
+
+  // Validate only the merge commit merge strategy is enabled.
+  assert {
+    condition     = resource.github_repository.default.allow_merge_commit == true
+    error_message = "Merge commit strategy is not enabled"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_squash_merge == false
+    error_message = "Squash merge strategy is not enabled"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_rebase_merge == false
+    error_message = "Rebase merge strategy is not enabled"
+  }
+}
+
+run "merge_strategy_rebase" {
+  variables {
+    name           = "merge-strategy-rebase-${run.setup.random_string}"
+    merge_strategy = "rebase"
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  assert {
+    condition     = resource.github_repository.default.name == "merge-strategy-rebase-${run.setup.random_string}"
+    error_message = "Name does not match"
+  }
+
+  // Validate only the rebase merge strategy is enabled.
+  assert {
+    condition     = resource.github_repository.default.allow_merge_commit == false
+    error_message = "Merge commit strategy should be false"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_rebase_merge == true
+    error_message = "Rebase merge strategy should be true"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_squash_merge == false
+    error_message = "Squash merge strategy should be false"
+  }
+}
+
+run "merge_strategy_squash" {
+  variables {
+    name           = "merge-strategy-squash-${run.setup.random_string}"
+    merge_strategy = "squash"
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  assert {
+    condition     = resource.github_repository.default.name == "merge-strategy-squash-${run.setup.random_string}"
+    error_message = "Name does not match"
+  }
+
+  // Validate only the squash merge strategy is enabled.
+  assert {
+    condition     = resource.github_repository.default.allow_merge_commit == false
+    error_message = "Merge commit strategy should be false"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_rebase_merge == false
+    error_message = "Rebase merge strategy should be false"
+  }
+  assert {
+    condition     = resource.github_repository.default.allow_squash_merge == true
+    error_message = "Squash merge strategy should be true"
+  }
+}
+
+# When merge_strategy has an invalid value, it should return an error.
+run "merge_strategy_error" {
+  variables {
+    name           = "merge-strategy-error-${run.setup.random_string}"
+    merge_strategy = "squash-commit"
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  expect_failures = [
+    var.merge_strategy,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -40,13 +40,13 @@ variable "allow_auto_merge" {
 
 variable "allow_merge_commit" {
   type        = bool
-  default     = false
+  default     = true
   description = "Enable merge commits on the repository"
 }
 
 variable "allow_rebase_merge" {
   type        = bool
-  default     = false
+  default     = true
   description = "Enable rebase merges on the repository"
 }
 
@@ -289,6 +289,17 @@ variable "merge_commit_title" {
   validation {
     condition     = can(regex("^(PR_TITLE|MERGE_MESSAGE)$", var.merge_commit_title))
     error_message = "The value of the variable 'merge_commit_title' must be one of 'PR_TITLE' or 'MERGE_MESSAGE'"
+  }
+}
+
+variable "merge_strategy" {
+  type        = string
+  default     = null
+  description = "The merge strategy to use for pull requests"
+
+  validation {
+    condition     = var.merge_strategy == null || can(regex("^(merge|rebase|squash)$", lower(var.merge_strategy)))
+    error_message = "The value of the variable 'merge_strategy' must be one of 'merge', 'rebase' or 'squash'"
   }
 }
 


### PR DESCRIPTION
## **:hammer_and_wrench: Summary**

This pull request introduces a new feature to configure merge strategies for GitHub repositories managed by the module. It adds a `merge_strategy` variable for simplified configuration, updates the default behavior for merge strategies, and includes new tests and examples to validate the functionality.

### Merge Strategy Configuration:

* Added a new `merge_strategy` variable, allowing users to specify a single merge strategy (`merge`, `rebase`, or `squash`). This variable overrides the individual `allow_merge_commit`, `allow_rebase_merge`, and `allow_squash_merge` settings. Validation ensures only valid values are accepted.
* Updated the logic in `main.tf` to use the `merge_strategy` variable when set, falling back to the individual merge strategy variables otherwise.

### Documentation and Examples:

* Updated the `README.md` to include instructions for using the `merge_strategy` variable and its impact on other settings.
* Added a new example in `examples/merge-strategy/main.tf` demonstrating the use of the `merge_strategy` variable.

### Testing:

* Added test cases in `tests/basic.tftest.hcl` to validate the behavior of the `merge_strategy` variable, including scenarios for each strategy, default behavior, and invalid values.

### Default Behavior Changes:

* Changed the default values of `allow_merge_commit`, `allow_rebase_merge`, and `allow_squash_merge` to `true`, enabling all merge strategies by default unless overridden.

## **:rocket: Motivation**

This option was added to expose the setting to Enablement Platform users, so that they can select their desired merge strategy without needing to change multiple variables.

In the last major version we defaulted to only enable squash merge; this was because we saw people choosing different merge types when all options were available, making for a messy commit history.

This commit adds `var.merge_strategy` which allows the consumer to select a merge strategy for the repo. This variable defaults to `null` so that if it's not explicitly set, all merge strategies are enabled by default, as was the case before.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
