### PR TITLE
fix(environment-module): Handle null inputs better

### DIFF
--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -7,6 +7,7 @@ variable "deployment_policy" {
   })
   default     = {}
   description = "Environment deployment policy."
+  nullable    = false
 }
 
 variable "name" {
@@ -47,12 +48,14 @@ variable "secrets" {
   type        = map(string)
   description = "A map of environment secrets to create."
   default     = {}
+  nullable    = false
 }
 
 variable "variables" {
   type        = map(string)
   description = "A map of environment variables to create."
   default     = {}
+  nullable    = false
 }
 
 variable "wait_timer" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Set `nullable = false` for variables with empty types (e.g. `{}` or `[]`). We set it for `deployment_policy` so that if someone does pass in null, we still do the good thing of adding the policy for protected branches. If they really want to opt out, they can do so with `protected_branches = false`.

## :rocket: Motivation

It's a nicer user experience to pass `null` than the empty type, e.g. `{}` or `[]` (think calling this module using a `for_each` from another module.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
