### PR TITLE
fix!: Remove computable values from `var.deployment_policy`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ module "environment" {
   source = "./modules/environment"
 
   name              = each.key
-  deployment_policy = each.value.deployment_branch_policy
+  deployment_policy = each.value.deployment_policy
   repository        = github_repository.default.name
   reviewer_teams    = try(each.value.reviewers.teams, null)
   reviewer_users    = try(each.value.reviewers.users, null)

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -1,9 +1,7 @@
 variable "deployment_policy" {
   type = object({
-    branch_patterns        = optional(set(string), [])
-    custom_branch_policies = optional(bool, false)
-    protected_branches     = optional(bool, true)
-    tag_patterns           = optional(set(string), [])
+    branch_patterns = optional(set(string), [])
+    tag_patterns    = optional(set(string), [])
   })
   default     = {}
   description = "Environment deployment policy."

--- a/variables.tf
+++ b/variables.tf
@@ -200,22 +200,15 @@ variable "environments" {
     variables  = optional(map(string), {})
     wait_timer = optional(number, null)
 
-    deployment_branch_policy = optional(object(
-      {
-        branch_patterns        = optional(list(string), [])
-        custom_branch_policies = optional(bool, false)
-        protected_branches     = optional(bool, true)
-      }),
-      {
-        custom_branch_policies = false
-        protected_branches     = true
-      }
-    )
+    deployment_policy = optional(object({
+      branch_patterns = optional(set(string), [])
+      tag_patterns    = optional(set(string), [])
+    }))
 
     reviewers = optional(object({
       teams = optional(list(string)) # Use team names here
-      users = optional(list(string)) # USe user names here
-    }), null)
+      users = optional(list(string)) # Use user names here
+    }))
   }))
   default     = {}
   description = "An optional map of GitHub environments to configure"


### PR DESCRIPTION
When creating an environment the default behaviour is to have `var.deployment_policy`'s `protected_branches` set to true and `custom_branch_policies` set to false, as these values are mutually exclusive. If you configure `branch_patterns` or `tag_patterns`, you have to set custom_branch_policies to `true` and `protected_branches` to false -- this is more cognitive load than we want for our users.

This commit removes the first two values: we keep the default of only allowing deployments from protected branches, but, if `branch_patterns` or `tag_patterns` are set, the module will handle setting the booleans to make them come into effect.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>

## :hammer_and_wrench: Summary

This pull request refactors how deployment branch policies are defined and applied to GitHub environments in the Terraform codebase. The main change is the consolidation of deployment policy configuration, replacing the previous individual boolean flags with a more flexible object that supports branch and tag patterns. The logic for determining whether to use protected branches or custom branch policies is now automated based on the presence of these patterns. Associated tests have been updated to validate the new behavior.

**Deployment Policy Refactor and Logic Improvements:**

* Replaced the previous `deployment_branch_policy` object (which used `custom_branch_policies` and `protected_branches` booleans) with a new `deployment_policy` object that supports `branch_patterns` and `tag_patterns`, simplifying and clarifying environment configuration.
* Added logic in `modules/environment/main.tf` to automatically set `protected_branches` to true when no branch or tag patterns are specified, and to use custom branch policies otherwise. This ensures the correct deployment policy is applied based on the configuration.

**Test Updates:**

* Updated and expanded tests in `tests/environments.tftest.hcl` to verify the new deployment policy logic, including cases for default protected branches and custom branch/tag patterns.

## :rocket: Motivation

We shouldn't expose variables if we can handle the logic internally. In this case if someone set the desired tag or branch patterns, it would not work without adjusting the other values, so we may as well take care of this for the module consumer.