### PR TITLE
chore: Prep for v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,32 @@ module "mcaf-repository" {
 
 See the [github_branch resource](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch) for more details
 
+## Creating files
+
+This module allows creating and managing files in a GitHub repository by using `var.repository_files`.
+
+To create files:
+
+```hcl
+module "mcaf-repository" {
+  source = "schubergphilis/mcaf-repository/github"
+
+  name = "my-repo"
+
+  repository_files = {
+    ".github/dependabot.yml" = {
+      content = file("${path.root}/files/dependabot.yml")
+    }
+    "README.md" = {
+      content = "Welcome to my project!"
+      managed = false
+    }
+  }
+}
+```
+
+The map key refers to the file path in the repository, and the `content` field contains the file content. By default, files created using this method are managed by Terraform, but this can be changed by setting the `managed` field to `false`, meaning any changes done outside of Terraform will be ignored.
+
 ## Configuring (additional) branches
 
 The default behaviour is for any branch created by this branch to inherit the default branch protection settings (`var.default_branch_protection`), but this can be overridden by either settings the `branch_protection` key or disabling branch protection by setting the `use_branch_protection` field to `false`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,69 @@
 
 This document captures breaking changes.
 
+When upgrading, it is important to go from one major version to the next. Skipping major versions may cause errors that are not documented here.
+
+## Upgrading to v4.0.0
+
+### `repository_files`: Use map key in favour of `path` attribute
+
+The `repository_files` variable now expects each map key to define the file path. The `path` attribute is no longer supported and will cause errors.
+
+**Old syntax:**
+
+```hcl
+repository_files = {
+  "foo.txt" = {
+    path    = "/path/to/foo.txt"
+    content = file("foo.txt")
+  }
+}
+```
+
+**New syntax:**
+
+```hcl
+repository_files = {
+  "/path/to/foo.txt" = {
+    content = file("foo.txt")
+  }
+}
+```
+
+### `deployment_policy`: Consolidated object with computed logic
+
+> [!NOTE]
+> This change applies to the variable in the root module and the `environment` sub-module.
+
+Renamed `deployment_branch_policy` to `deployment_policy`: this variable is used to configure tag and branch patterns for deployments so removed `branch` from the name.
+
+The prior boolean flags, `protected_branches` and `custom_branch_policies`, have been removed. Instead, only `branch_patterns` and `tag_patterns` should be used. The former needed to be set depending on how the latter were set, we now handle this inside the module.
+
+- If neither `branch_patterns` nor `tag_patterns` are defined, the module defaults to `protected_branches = true`.
+- If either is defined, the module will automatically handle enabling custom branch/tag logic and disabling `protected_branches`.
+
+This change maintains the original behaviour, where not configuring `deployment_policy` results in `protected_branches = true`, only allowing deployments from protected branches.
+
+**Old syntax:**
+
+```hcl
+deployment_policy = {
+  protected_branches     = true
+  custom_branch_policies = false
+  branch_patterns        = []
+  tag_patterns           = []
+}
+```
+
+**New syntax:**
+
+```hcl
+deployment_policy = {
+  branch_patterns = ["releas*"]
+  tag_patterns    = ["v*"]
+}
+```
+
 ## Upgrading to v3.0.0
 
 ### Move environment configuration to its own module


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This pull request updates documentation to introduce new features and clarify breaking changes for the `mcaf-repository` Terraform module. The most important changes are the addition of support for managing files in repositories and the consolidation of deployment policy configuration. These updates improve usability and help users upgrade smoothly to v4.0.0.

**New Features and Usage:**

* Added documentation in `README.md` for creating and managing files in a GitHub repository using the `repository_files` variable, including example usage and explanation of the `managed` field.

**Breaking Changes and Upgrade Guidance:**

* Updated `UPGRADING.md` to explain that the `repository_files` variable now uses the map key for the file path instead of a `path` attribute, with examples of old and new syntax.
* Documented the consolidation of deployment policy configuration: renamed `deployment_branch_policy` to `deployment_policy`, removed boolean flags (`protected_branches`, `custom_branch_policies`), and clarified new logic for `branch_patterns` and `tag_patterns`, with migration examples.

## :rocket: Motivation

Couldn't put notes into UPGRADING.md in the PRs because it would cause merge conflicts, so made a follow up PR.

<!-- Why is this change required? What problem does it solve? -->
