### PR TITLE
feat: add support for github_workflow_repository_permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ module "mcaf-repository" {
 | [github_repository_file.unmanaged](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_ruleset.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
 | [github_team_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_workflow_repository_permissions.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/workflow_repository_permissions) | resource |
 | [github_team.default](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/team) | data source |
 
 ## Inputs
@@ -318,6 +319,7 @@ module "mcaf-repository" {
 | <a name="input_topics"></a> [topics](#input\_topics) | A list of topics to set on the repository | `list(string)` | `[]` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Set the GitHub repository as public, private or internal | `string` | `"private"` | no |
 | <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | Set to true to enable security alerts for vulnerable dependencies | `bool` | `true` | no |
+| <a name="input_workflow_permissions"></a> [workflow\_permissions](#input\_workflow\_permissions) | An optional object to configure GitHub Actions workflow permissions for the repository | <pre>object({<br/>    default_workflow_permissions     = optional(string, null)<br/>    can_approve_pull_request_reviews = optional(bool, false)<br/>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -256,6 +256,14 @@ resource "github_team_repository" "default" {
 # Actions
 ################################################################################
 
+resource "github_workflow_repository_permissions" "default" {
+  count = var.workflow_permissions != null ? 1 : 0
+
+  can_approve_pull_request_reviews = var.workflow_permissions.can_approve_pull_request_reviews
+  default_workflow_permissions     = var.workflow_permissions.default_workflow_permissions
+  repository                       = github_repository.default.name
+}
+
 resource "github_actions_repository_access_level" "actions_access_level" {
   count = var.actions_access_level != null ? 1 : 0
 

--- a/tests/basic.tftest.hcl
+++ b/tests/basic.tftest.hcl
@@ -20,6 +20,12 @@ run "basic" {
     error_message = "Name does not match"
   }
 
+  // Validate no workflow permissions resource is created by default
+  assert {
+    condition     = length(resource.github_workflow_repository_permissions.default) == 0
+    error_message = "Workflow permissions should not be created by default"
+  }
+
   // Validate no autolink references exist
   assert {
     condition     = length(resource.github_repository_autolink_reference.default) == 0
@@ -182,6 +188,82 @@ run "source_repo_rejects_empty_repo" {
   command = plan
 
   expect_failures = [var.source_repo]
+}
+
+# Test workflow_permissions with explicit values
+run "workflow_permissions_set" {
+  variables {
+    name = "workflow-permissions-set-${run.setup.random_string}"
+    workflow_permissions = {
+      default_workflow_permissions     = "read"
+      can_approve_pull_request_reviews = false
+    }
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(resource.github_workflow_repository_permissions.default) == 1
+    error_message = "Workflow permissions resource should be created"
+  }
+
+  assert {
+    condition     = resource.github_workflow_repository_permissions.default[0].default_workflow_permissions == "read"
+    error_message = "Default workflow permissions should be 'read'"
+  }
+
+  assert {
+    condition     = resource.github_workflow_repository_permissions.default[0].can_approve_pull_request_reviews == false
+    error_message = "Can approve pull request reviews should be false"
+  }
+}
+
+# Test workflow_permissions with defaults applied
+run "workflow_permissions_defaults" {
+  variables {
+    name                 = "workflow-permissions-defaults-${run.setup.random_string}"
+    workflow_permissions = {}
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(resource.github_workflow_repository_permissions.default) == 1
+    error_message = "Workflow permissions resource should be created"
+  }
+
+  assert {
+    condition     = resource.github_workflow_repository_permissions.default[0].can_approve_pull_request_reviews == false
+    error_message = "Can approve pull request reviews should default to false"
+  }
+}
+
+# Test workflow_permissions validation rejects invalid values
+run "workflow_permissions_invalid" {
+  variables {
+    name = "workflow-permissions-invalid-${run.setup.random_string}"
+    workflow_permissions = {
+      default_workflow_permissions = "admin"
+    }
+  }
+
+  module {
+    source = "./"
+  }
+
+  command = plan
+
+  expect_failures = [
+    var.workflow_permissions,
+  ]
 }
 
 # var.merge_strategy is not set by default, the default behavior is to enable all merge strategies.

--- a/variables.tf
+++ b/variables.tf
@@ -429,3 +429,17 @@ variable "vulnerability_alerts" {
   default     = true
   description = "Set to true to enable security alerts for vulnerable dependencies"
 }
+
+variable "workflow_permissions" {
+  type = object({
+    default_workflow_permissions     = optional(string, null)
+    can_approve_pull_request_reviews = optional(bool, false)
+  })
+  default     = null
+  description = "An optional object to configure GitHub Actions workflow permissions for the repository"
+
+  validation {
+    condition     = var.workflow_permissions == null || var.workflow_permissions.default_workflow_permissions == null || can(regex("^(read|write)$", var.workflow_permissions.default_workflow_permissions))
+    error_message = "The value of 'default_workflow_permissions' must be one of 'read' or 'write'"
+  }
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Add support for the `github_workflow_repository_permissions` resource, allowing users to configure GitHub Actions workflow permissions at the repository level via a new `workflow_permissions` variable.

## :rocket: Motivation

GitHub Actions workflows by default inherit permissions from the organization level, but repositories may need to override these with more restrictive settings. This change enables managing `default_workflow_permissions` and `can_approve_pull_request_reviews` per repository through Terraform, promoting a secure-by-default configuration where workflows cannot approve pull request reviews.

## :pencil: Additional Information

- The `github_workflow_repository_permissions` resource has been available since provider v6.8.0; this module already requires `~> 6.11`.
- The new `workflow_permissions` variable defaults to `null`, meaning no resource is created unless explicitly configured — this is fully non-breaking for existing users.
- When provided, the secure defaults are:
  - `default_workflow_permissions = null` (inherits from organization)
  - `can_approve_pull_request_reviews = false`
- Validation ensures `default_workflow_permissions` only accepts `"read"`, `"write"`, or `null`.
- Tests added to `tests/basic.tftest.hcl` covering: default (not created), explicit values, object defaults, and validation rejection.
