### PR TITLE
fix: var.workflow_permissions condition errors out when null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -450,7 +450,7 @@ variable "workflow_permissions" {
   description = "An optional object to configure GitHub Actions workflow permissions for the repository"
 
   validation {
-    condition     = var.workflow_permissions == null || var.workflow_permissions.default_workflow_permissions == null || can(regex("^(read|write)$", var.workflow_permissions.default_workflow_permissions))
+    condition     = var.workflow_permissions == null || try(var.workflow_permissions.default_workflow_permissions, null) == null || can(regex("^(read|write)$", var.workflow_permissions.default_workflow_permissions))
     error_message = "The value of 'default_workflow_permissions' must be one of 'read' or 'write'"
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Fixes a condition validation error if `var.workflow_permissions` is set to `null` (which is a default value)

## :rocket: Motivation

When `var.workflow_permissions` is set to `null` plan fails with error such as

```
Error: Attempt to get attribute from null value
on <DIR>/variables.tf line 453, in variable "workflow_permissions":
    condition     = var.workflow_permissions == null || var.workflow_permissions.default_workflow_permissions == null || can(regex("^(read|write)$", var.workflow_permissions.default_workflow_permissions))
var.workflow_permissions is null
This value is null, so it does not have any attributes.
```

## :pencil: Additional Information

Terraform only supports short-circuiting conditions starting with 1.12, since the module only requires 1.9.0, this should be fixed