### PR TITLE
feat!: migrate pages to the dedicated github_repository_pages resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ module "mcaf-repository" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.11 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.12 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.11 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.12 |
 
 ## Modules
 
@@ -264,6 +264,7 @@ module "mcaf-repository" {
 | [github_repository_dependabot_security_updates.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_dependabot_security_updates) | resource |
 | [github_repository_file.managed](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.unmanaged](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_pages.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_pages) | resource |
 | [github_repository_ruleset.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
 | [github_team_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_workflow_repository_permissions.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/workflow_repository_permissions) | resource |
@@ -309,7 +310,7 @@ module "mcaf-repository" {
 | <a name="input_merge_commit_message"></a> [merge\_commit\_message](#input\_merge\_commit\_message) | The default commit message for merge commits | `string` | `"PR_BODY"` | no |
 | <a name="input_merge_commit_title"></a> [merge\_commit\_title](#input\_merge\_commit\_title) | The default commit title for merge commits | `string` | `"PR_TITLE"` | no |
 | <a name="input_merge_strategy"></a> [merge\_strategy](#input\_merge\_strategy) | The merge strategy to use for pull requests | `string` | `null` | no |
-| <a name="input_pages"></a> [pages](#input\_pages) | The repository's GitHub Pages configuration. | <pre>object({<br/>    build_type = string<br/>    branch     = optional(string)<br/>    cname      = optional(string)<br/>    path       = optional(string, "/")<br/>  })</pre> | `null` | no |
+| <a name="input_pages"></a> [pages](#input\_pages) | The repository's GitHub Pages configuration. | <pre>object({<br/>    build_type     = string<br/>    branch         = optional(string)<br/>    cname          = optional(string)<br/>    https_enforced = optional(bool)<br/>    path           = optional(string, "/")<br/>    public         = optional(bool)<br/>  })</pre> | `null` | no |
 | <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A map of GitHub repository files that should be created | <pre>map(object({<br/>    branch              = optional(string)<br/>    commit_message      = optional(string)<br/>    commit_prefix       = optional(string)<br/>    content             = string<br/>    managed             = optional(bool, true)<br/>    overwrite_on_create = optional(bool, false)<br/>    skip_ci             = optional(bool, false)<br/>  }))</pre> | `{}` | no |
 | <a name="input_source_repo"></a> [source\_repo](#input\_source\_repo) | The source repository to create this repository from in format owner/repo | `string` | `null` | no |
 | <a name="input_squash_merge_commit_message"></a> [squash\_merge\_commit\_message](#input\_squash\_merge\_commit\_message) | The default commit message for squash merges | `string` | `"COMMIT_MESSAGES"` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,34 @@ This document captures breaking changes.
 
 When upgrading, it is important to go from one major version to the next. Skipping major versions may cause errors that are not documented here.
 
+## Upgrading to v6.0.0
+
+### `pages`: migrated to the dedicated `github_repository_pages` resource
+
+The inline `pages` block on `github_repository` is deprecated by the GitHub provider. The module now manages GitHub Pages via the dedicated `github_repository_pages` resource.
+
+To avoid disrupting existing Pages configuration, the module sets `lifecycle.ignore_changes = [pages]` on `github_repository`. The deprecated inline state is left in place; the new resource becomes the source of truth.
+
+To migrate existing Pages config under the new resource without disruption, add an `import` block in your root module before applying:
+
+```hcl
+import {
+  to = module.<your_module_alias>.github_repository_pages.default[0]
+  id = "<repository_name>"
+}
+```
+
+After a successful apply, remove the `import` block. Repositories that do not use `var.pages` require no migration.
+
+The `var.pages` object now also accepts:
+
+- `https_enforced` — enforce HTTPS for the Pages site (requires `cname`).
+- `public` — whether the Pages site is public.
+
+## Upgrading to v5.0.0
+
+The `has_downloads` variables is removed.
+
 ## Upgrading to v4.0.0
 
 ### `repository_files`: Use map key in favour of `path` attribute

--- a/main.tf
+++ b/main.tf
@@ -61,24 +61,6 @@ resource "github_repository" "default" {
   visibility                  = var.visibility
   vulnerability_alerts        = var.vulnerability_alerts
 
-  dynamic "pages" {
-    for_each = var.pages != null ? { create = true } : {}
-
-    content {
-      build_type = var.pages.build_type
-      cname      = var.pages.cname
-
-      dynamic "source" {
-        for_each = var.pages.build_type == "legacy" ? { create = true } : {}
-
-        content {
-          branch = var.pages.branch
-          path   = var.pages.path
-        }
-      }
-    }
-  }
-
   dynamic "template" {
     for_each = var.template_repository != null ? { create = true } : {}
 
@@ -89,13 +71,11 @@ resource "github_repository" "default" {
   }
 
   lifecycle {
-    ignore_changes = [template]
+    # `pages` is ignored because it is managed by the dedicated
+    # `github_repository_pages` resource below; the inline block on
+    # `github_repository` is deprecated by the provider.
+    ignore_changes = [pages, template]
   }
-}
-
-moved {
-  from = github_repository_dependabot_security_updates.default
-  to   = github_repository_dependabot_security_updates.default[0]
 }
 
 # Configure an autolink reference.
@@ -120,13 +100,34 @@ resource "github_repository_custom_property" "default" {
 
 # Configure Dependabot security updates for the repository.
 resource "github_repository_dependabot_security_updates" "default" {
-  count      = var.vulnerability_alerts ? 1 : 0
+  count = var.vulnerability_alerts ? 1 : 0
+
   repository = github_repository.default.name
   enabled    = var.dependabot_enabled
 
   depends_on = [
     github_repository.default
   ]
+}
+
+# Configure GitHub Pages for the repository.
+resource "github_repository_pages" "default" {
+  count = var.pages != null ? 1 : 0
+
+  build_type     = var.pages.build_type
+  cname          = var.pages.cname
+  https_enforced = var.pages.https_enforced
+  public         = var.pages.public
+  repository     = github_repository.default.name
+
+  dynamic "source" {
+    for_each = var.pages.build_type == "legacy" ? { create = true } : {}
+
+    content {
+      branch = var.pages.branch
+      path   = var.pages.path
+    }
+  }
 }
 
 resource "github_dependabot_secret" "plaintext" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 6.11"
+      version = ">= 6.12"
     }
   }
   required_version = ">= 1.9.0"

--- a/variables.tf
+++ b/variables.tf
@@ -333,10 +333,12 @@ variable "name" {
 
 variable "pages" {
   type = object({
-    build_type = string
-    branch     = optional(string)
-    cname      = optional(string)
-    path       = optional(string, "/")
+    build_type     = string
+    branch         = optional(string)
+    cname          = optional(string)
+    https_enforced = optional(bool)
+    path           = optional(string, "/")
+    public         = optional(bool)
   })
 
   default     = null
@@ -350,6 +352,11 @@ variable "pages" {
   validation {
     condition     = (var.pages == null || try(var.pages.build_type != "legacy" || (var.pages.branch != null && var.pages.branch != ""), true))
     error_message = "The variable 'branch' is required when 'build_type' is set to 'legacy'"
+  }
+
+  validation {
+    condition     = (var.pages == null || try(var.pages.https_enforced != true || (var.pages.cname != null && var.pages.cname != ""), true))
+    error_message = "The variable 'cname' is required when 'https_enforced' is set to true"
   }
 }
 


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Migrate GitHub Pages configuration from the deprecated inline pages block on `github_repository` to the dedicated `github_repository_pages` resource. The `var.pages` object gains two optional fields, `https_enforced` and `public`.

## :rocket: Motivation

The inline pages nested block on `github_repository` is deprecated by the GitHub provider ("This field will be removed in a future version."). Moving to the dedicated resource keeps the module forward-compatible and unblocks future provider upgrades. Exposing `https_enforced` and `public` brings the module's API in line with the new resource surface.
