### PR TITLE
chore: Move vulnerability_alerts to separate resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ module "mcaf-repository" {
 | [github_repository_file.unmanaged](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_pages.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_pages) | resource |
 | [github_repository_ruleset.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
+| [github_repository_vulnerability_alerts.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_vulnerability_alerts) | resource |
 | [github_team_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_workflow_repository_permissions.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/workflow_repository_permissions) | resource |
 | [github_team.default](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/team) | data source |

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,6 @@ resource "github_repository" "default" {
   squash_merge_commit_title   = var.squash_merge_commit_title
   topics                      = var.topics
   visibility                  = var.visibility
-  vulnerability_alerts        = var.vulnerability_alerts
 
   dynamic "template" {
     for_each = var.template_repository != null ? { create = true } : {}
@@ -144,6 +143,11 @@ resource "github_dependabot_secret" "encrypted" {
   repository      = github_repository_dependabot_security_updates.default[0].repository
   secret_name     = each.key
   encrypted_value = each.value
+}
+
+resource "github_repository_vulnerability_alerts" "default" {
+  repository = github_repository.default.name
+  enabled    = var.vulnerability_alerts
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -29,8 +29,8 @@ locals {
 # Repository
 ################################################################################
 
-#tfsec:ignore:github-repositories-vulnerability-alerts
 resource "github_repository" "default" {
+  # checkov:skip=CKV_GIT_3:Ensure GitHub repository has vulnerability alerts enabled - False positive, this is configured in the separate `github_repository_vulnerability_alerts` resource below. See issue https://github.com/bridgecrewio/checkov/issues/7546
   name                        = var.name
   allow_auto_merge            = var.allow_auto_merge
   allow_merge_commit          = local.allow_merge_commit


### PR DESCRIPTION
## :hammer_and_wrench: Summary

The `vulnerability_alerts` setting is moved from the repository resource to it's own separate resource, making the "old" setting obsolete:

<img width="763" height="88" alt="image" src="https://github.com/user-attachments/assets/3827b546-dbf3-4ec1-938e-4c4436003d52" />

This PR moves the configuration to this new resource. Should have no functional impact (variable is the same, configuration is the same. Just a different resource under the hood). Provider version is already set to 6.12

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

PR: https://github.com/integrations/terraform-provider-github/pull/3166