### PR TITLE
fix: plaintext_value argument is deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,9 +132,9 @@ resource "github_repository_pages" "default" {
 resource "github_dependabot_secret" "plaintext" {
   for_each = var.dependabot_plaintext_secrets
 
-  repository      = github_repository_dependabot_security_updates.default[0].repository
-  secret_name     = each.key
-  plaintext_value = each.value
+  repository  = github_repository_dependabot_security_updates.default[0].repository
+  secret_name = each.key
+  value       = each.value
 }
 
 resource "github_dependabot_secret" "encrypted" {
@@ -291,12 +291,11 @@ resource "github_actions_repository_access_level" "actions_access_level" {
 }
 
 resource "github_actions_secret" "secrets" {
-  # checkov:skip=CKV_GIT_4:Ensure GitHub Actions secrets are encrypted - plaintext_value is a sensitive argument and there is no value in using a base64 encoded value here
   for_each = var.actions_secrets
 
-  plaintext_value = each.value
-  repository      = github_repository.default.name
-  secret_name     = each.key
+  repository  = github_repository.default.name
+  secret_name = each.key
+  value       = each.value
 }
 
 resource "github_actions_variable" "action_variables" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

In provider version 6.12.0 the `plaintext_value` argument in `github_dependabot_secret` and `github_actions_secret` is marked as deprecated. Since 6.12.0 is the minimum supported version by the module we should not keep using deprecated arguments.

## :rocket: Motivation

Deprecations in the provider. When using the `plaintext_value` argument, user is presented with warning such as
```
Warning: Argument is deprecated
with module.github_repository on .terraform/modules/github_repositories/main.tf line 297, in resource "github_actions_secret" "secrets":
  plaintext_value = each.value
Use value.
```

## :pencil: Additional Information

See PR https://github.com/integrations/terraform-provider-github/pull/3225 released in [v6.12.0](https://github.com/integrations/terraform-provider-github/releases/tag/v6.12.0)
