### PR TITLE
fix: order dependabot security updates after vulnerability alerts and  solve deprecation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,9 +104,8 @@ resource "github_repository_dependabot_security_updates" "default" {
   repository = github_repository.default.name
   enabled    = var.dependabot_enabled
 
-  depends_on = [
-    github_repository.default
-  ]
+  # GitHub rejects any change to automated security fixes unless vulnerability alerts are enabled. 
+  depends_on = [github_repository_vulnerability_alerts.default]
 }
 
 # Configure GitHub Pages for the repository.
@@ -142,7 +141,7 @@ resource "github_dependabot_secret" "encrypted" {
 
   repository      = github_repository_dependabot_security_updates.default[0].repository
   secret_name     = each.key
-  encrypted_value = each.value
+  value_encrypted = each.value
 }
 
 resource "github_repository_vulnerability_alerts" "default" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

- Add a `depends_on` from `github_repository_dependabot_security_updates` to `github_repository_vulnerability_alerts`. GitHub requires vulnerability alerts to be enabled before automated security fixes can be configured. Without the dependency, Terraform may create both in parallel and hit: `422 Vulnerability alerts must be enabled to configure automated security fixes.` The explicit dependency forces alerts to be enabled first.
- Solve deprecation warning of the `github_dependabot_secret` resource: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/dependabot_secret#encrypted_value-1 