### PR TITLE
fix: rewrite plaintext_value argument on github_actions_environment_secret as it is deprecated

### DIFF
--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -58,10 +58,10 @@ resource "github_actions_environment_secret" "default" {
   # checkov:skip=CKV_GIT_4:Ensure GitHub Actions secrets are encrypted - plaintext_value is a sensitive argument and there is no value in using a base64 encoded value here
   for_each = var.secrets
 
-  environment     = github_repository_environment.default.environment
-  plaintext_value = each.value
-  repository      = var.repository
-  secret_name     = each.key
+  environment = github_repository_environment.default.environment
+  repository  = var.repository
+  secret_name = each.key
+  value       = each.value
 }
 
 # FIXME: This can be removed in the next major release (v4)

--- a/tests/environments.tftest.hcl
+++ b/tests/environments.tftest.hcl
@@ -188,8 +188,8 @@ run "secrets" {
     error_message = "Secret name does not match: expected mysecret, got ${github_actions_environment_secret.default["mysecret"].secret_name}"
   }
   assert {
-    condition     = github_actions_environment_secret.default["mysecret"].plaintext_value == "myvalue"
-    error_message = "Secret value does not match: expected myvalue, got ${nonsensitive(github_actions_environment_secret.default["mysecret"].plaintext_value)}"
+    condition     = github_actions_environment_secret.default["mysecret"].value == "myvalue"
+    error_message = "Secret value does not match: expected myvalue, got ${nonsensitive(github_actions_environment_secret.default["mysecret"].value)}"
   }
 }
 


### PR DESCRIPTION
## :hammer_and_wrench: Summary

In provider version 6.12.0 the `plaintext_value` argument in `github_actions_environment_secret` is marked as deprecated. We already did a fix via #112, but this also picks up environment secrets.

## :rocket: Motivation

Clean up deprecation warnings in the provider. 

## :pencil: Additional Information

See PR https://github.com/integrations/terraform-provider-github/pull/3225 released in [v6.12.0](https://github.com/integrations/terraform-provider-github/releases/tag/v6.12.0)
