### PR TITLE
fix: prevent branch protection replacement when importing existing rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -212,6 +212,17 @@ resource "github_branch_protection" "default" {
     }
   }
 
+  lifecycle {
+    # `repository_id` is set to the repository name on create, but the GitHub
+    # provider stores the repository node ID when a rule is imported. Since
+    # `repository_id` forces replacement, importing an existing rule would
+    # otherwise destroy and recreate branch protection, briefly leaving the
+    # branch unprotected. The repository association never legitimately changes
+    # for a given module instance, so ignoring it is safe and also prevents
+    # churn when the repository is renamed.
+    ignore_changes = [repository_id]
+  }
+
   depends_on = [
     github_branch.default,
   ]


### PR DESCRIPTION
## Problem

Importing an existing `github_branch_protection` rule managed by this module plans a **destroy/recreate**, which briefly leaves the branch unprotected:

```
~ repository_id = "R_kgDO..." -> "inception"  # forces replacement
```

### Root cause

The module sets `repository_id = github_repository.default.name`, but the GitHub provider behaves asymmetrically for this `required` (non-computed, ForceNew) attribute:

- **On create** the provider preserves the config value (the repo **name**) in state, and `Read` never normalizes it.
- **On import** the provider resolves and stores the repository **node ID** (`getRepositoryID` always returns the GraphQL ID).

So a created rule has the name in state while an imported rule has the node ID. Since `repository_id` forces replacement, config (`name`) ≠ state (`node ID`) → replacement on the first plan after import.

No single static value satisfies both populations. Switching to `node_id` would fix imports but **force-replace branch protection for every existing consumer** (state holds the name) — a breaking change.

## Fix

Ignore changes to `repository_id` on `github_branch_protection.default`:

```hcl
lifecycle {
  ignore_changes = [repository_id]
}
```

The repository association never legitimately changes for a given module instance, so this is **non-breaking** and:

- lets existing rules be imported with no replacement (no unprotected window);
- leaves created rules untouched (no state migration, no major version);
- additionally prevents churn when a repository is **renamed** (the node ID is stable; today a rename force-replaces protection).

## Testing

- `terraform fmt` / `terraform validate` pass.
- Mock-based suites pass locally (`environments`, `repository_file` — 11 passed, 0 failed).
- `branches.tftest.hcl` (real provider, auth-gated) runs in CI.